### PR TITLE
shuffle generated password

### DIFF
--- a/internal/password/password.go
+++ b/internal/password/password.go
@@ -65,5 +65,10 @@ func Generate(passwordLength int, includeUpperCase, includeNum, includeSymbol bo
 		}
 	}
 
-	return password.String(), nil
+	pswd := []rune(password.String())
+	rand.Shuffle(len(pswd), func(i, j int) {
+		pswd[i], pswd[j] = pswd[j], pswd[i]
+	})
+
+	return string(pswd), nil
 }


### PR DESCRIPTION
The current password generator generates passwords in the following order: `lowercase UPPERCASE NUM SYMBOL`
To make it more **difficult** or like a real password, the proposed version **shuffles** the generated password.