### PR TITLE
add stdin support for base64

### DIFF
--- a/cmd/base64.go
+++ b/cmd/base64.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
+	"io"
 	"log"
 	"swiss/internal/base64"
 )
@@ -17,6 +18,14 @@ var base64EncodeCmd = &cobra.Command{
 	Use:   "encode",
 	Short: "Encodes given string with base64",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if b64Value == "-" {
+			inputReader := cmd.InOrStdin()
+			b, err := io.ReadAll(inputReader)
+			if err != nil {
+				return err
+			}
+			b64Value = string(b)
+		}
 		fmt.Print(base64.Encode(b64Value))
 		return nil
 	},
@@ -26,6 +35,14 @@ var base64DecodeCmd = &cobra.Command{
 	Use:   "decode",
 	Short: "Decodes given base64 string",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if b64Value == "-" {
+			inputReader := cmd.InOrStdin()
+			b, err := io.ReadAll(inputReader)
+			if err != nil {
+				return err
+			}
+			b64Value = string(b)
+		}
 		res, err := base64.Decode(b64Value)
 		if err != nil {
 			return err

--- a/cmd/base64.go
+++ b/cmd/base64.go
@@ -53,12 +53,12 @@ var base64DecodeCmd = &cobra.Command{
 }
 
 func init() {
-	base64EncodeCmd.Flags().StringVar(&b64Value, "value", "", "string")
+	base64EncodeCmd.Flags().StringVarP(&b64Value, "value", "v", "", "string")
 	err := base64EncodeCmd.MarkFlagRequired("value")
 	if err != nil {
 		log.Fatalf("Please provide a valid string with --value parameter")
 	}
-	base64DecodeCmd.Flags().StringVar(&b64Value, "value", "", "string")
+	base64DecodeCmd.Flags().StringVarP(&b64Value, "value", "v", "", "string")
 	err = base64DecodeCmd.MarkFlagRequired("value")
 	if err != nil {
 		log.Fatalf("Please provide a valid string with --value parameter")


### PR DESCRIPTION
Get value from stdin to base64 sub commands. This functionality allows you to pipe numerous commands together.

```
echo "Mehmet" | swiss base64 encode -v - | swiss base64 decode -v -
```

> Similar usecase from kubectl `kubectl apply -f -`