### PR TITLE
Add 22 new developer utilities (jwt, hash, diff, uuid, ip, cron, …)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,66 @@ More installation options will come
   - [x] ToYAML
   - [x] Escape
   - [x] Unescape
+- [x] JWT
+  - [x] Decode
+  - [x] Verify (HS256)
+- [x] Hash
+  - [x] MD5 / SHA1 / SHA256 / SHA512 / CRC32
+- [x] Hex
+  - [x] Encode
+  - [x] Decode
+- [x] Gzip
+  - [x] Compress
+  - [x] Decompress
+- [x] Bcrypt
+  - [x] Hash
+  - [x] Verify
+- [x] Base58
+  - [x] Encode
+  - [x] Decode
+- [x] UUID
+  - [x] Generate (v4 / v7)
+  - [x] Validate
+- [x] Cert
+  - [x] Info (x509/PEM)
+- [x] Text
+  - [x] Count (chars / words / lines / reading time)
+- [x] Case
+  - [x] camel / pascal / snake / kebab / title / upper / lower
+- [x] Slug
+  - [x] Make
+- [x] Lorem
+  - [x] Words / Sentences / Paragraphs
+- [x] Diff
+  - [x] Lines
+- [x] Regex
+  - [x] Match
+  - [x] Replace
+- [x] HTML
+  - [x] Escape
+  - [x] Unescape
+  - [x] Strip
+- [x] SQL
+  - [x] Format
+  - [x] Minify
+- [x] TOML
+  - [x] ToJSON
+  - [x] ToYAML
+  - [x] FromJSON
+- [x] JQ
+  - [x] Query (JSON path)
+- [x] IP
+  - [x] CIDR
+  - [x] ToInt
+  - [x] FromInt
+- [x] Cron
+  - [x] Explain
+  - [x] Next
+- [x] Color
+  - [x] ToRGB
+  - [x] ToHex
+  - [x] ToHSL
+- [x] Time
+  - [x] Now
+  - [x] ToUnix
+  - [x] FromUnix

--- a/cmd/base58.go
+++ b/cmd/base58.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/base58"
+
+	"github.com/spf13/cobra"
+)
+
+var base58Value string
+
+var base58Cmd = &cobra.Command{Use: "base58", Short: "base58 related utility functions"}
+
+var base58EncodeCmd = &cobra.Command{
+	Use:   "encode",
+	Short: "encodes input to base58",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := base58.Encode(base58Value)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var base58DecodeCmd = &cobra.Command{
+	Use:   "decode",
+	Short: "decodes base58 input",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := base58.Decode(base58Value)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{base58EncodeCmd, base58DecodeCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&base58Value, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		base58Cmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(base58Cmd)
+}

--- a/cmd/bcrypt.go
+++ b/cmd/bcrypt.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/bcrypt"
+
+	"github.com/spf13/cobra"
+)
+
+var bcryptValue string
+var bcryptPassword string
+
+var bcryptCmd = &cobra.Command{Use: "bcrypt", Short: "bcrypt related utility functions"}
+
+var bcryptHashCmd = &cobra.Command{
+	Use:   "hash",
+	Short: "hashes a password with bcrypt",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := bcrypt.Hash(bcryptValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var bcryptVerifyCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "verifies a password against a bcrypt hash",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := bcrypt.Verify(bcryptValue, bcryptPassword)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	bcryptHashCmd.Flags().StringVar(&bcryptValue, "value", "", "password to hash")
+	if err := bcryptHashCmd.MarkFlagRequired("value"); err != nil {
+		log.Fatalf("Please provide --value")
+	}
+
+	bcryptVerifyCmd.Flags().StringVar(&bcryptValue, "value", "", "bcrypt hash")
+	bcryptVerifyCmd.Flags().StringVar(&bcryptPassword, "password", "", "password to verify")
+	if err := bcryptVerifyCmd.MarkFlagRequired("value"); err != nil {
+		log.Fatalf("Please provide --value")
+	}
+	if err := bcryptVerifyCmd.MarkFlagRequired("password"); err != nil {
+		log.Fatalf("Please provide --password")
+	}
+
+	bcryptCmd.AddCommand(bcryptHashCmd)
+	bcryptCmd.AddCommand(bcryptVerifyCmd)
+	rootCmd.AddCommand(bcryptCmd)
+}

--- a/cmd/case.go
+++ b/cmd/case.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/textcase"
+
+	"github.com/spf13/cobra"
+)
+
+var caseValue string
+
+var caseCmd = &cobra.Command{Use: "case", Short: "case conversion utility functions"}
+
+var caseCamelCmd = &cobra.Command{
+	Use:   "camel",
+	Short: "converts to camelCase",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(textcase.ToCamel(caseValue))
+		return nil
+	},
+}
+
+var casePascalCmd = &cobra.Command{
+	Use:   "pascal",
+	Short: "converts to PascalCase",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(textcase.ToPascal(caseValue))
+		return nil
+	},
+}
+
+var caseSnakeCmd = &cobra.Command{
+	Use:   "snake",
+	Short: "converts to snake_case",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(textcase.ToSnake(caseValue))
+		return nil
+	},
+}
+
+var caseKebabCmd = &cobra.Command{
+	Use:   "kebab",
+	Short: "converts to kebab-case",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(textcase.ToKebab(caseValue))
+		return nil
+	},
+}
+
+var caseTitleCmd = &cobra.Command{
+	Use:   "title",
+	Short: "converts to Title Case",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(textcase.ToTitle(caseValue))
+		return nil
+	},
+}
+
+var caseUpperCmd = &cobra.Command{
+	Use:   "upper",
+	Short: "converts to UPPERCASE",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(textcase.ToUpper(caseValue))
+		return nil
+	},
+}
+
+var caseLowerCmd = &cobra.Command{
+	Use:   "lower",
+	Short: "converts to lowercase",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(textcase.ToLower(caseValue))
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{
+		caseCamelCmd,
+		casePascalCmd,
+		caseSnakeCmd,
+		caseKebabCmd,
+		caseTitleCmd,
+		caseUpperCmd,
+		caseLowerCmd,
+	}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&caseValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		caseCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(caseCmd)
+}

--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/cert"
+
+	"github.com/spf13/cobra"
+)
+
+var certValue string
+
+var certCmd = &cobra.Command{Use: "cert", Short: "cert related utility functions"}
+
+var certInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "shows information about a PEM certificate",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := cert.Info(certValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{certInfoCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&certValue, "value", "", "PEM encoded certificate")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		certCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(certCmd)
+}

--- a/cmd/color.go
+++ b/cmd/color.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/color"
+
+	"github.com/spf13/cobra"
+)
+
+var colorValue string
+
+var colorCmd = &cobra.Command{Use: "color", Short: "color related utility functions"}
+
+var colorToRGBCmd = &cobra.Command{
+	Use:   "toRGB",
+	Short: "converts a hex color to rgb",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := color.ToRGB(colorValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var colorToHexCmd = &cobra.Command{
+	Use:   "toHex",
+	Short: "converts an rgb color to hex",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := color.ToHex(colorValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var colorToHSLCmd = &cobra.Command{
+	Use:   "toHSL",
+	Short: "converts a hex color to hsl",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := color.ToHSL(colorValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{colorToRGBCmd, colorToHexCmd, colorToHSLCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&colorValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		colorCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(colorCmd)
+}

--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"swiss/internal/cron"
+
+	"github.com/spf13/cobra"
+)
+
+var cronValue string
+var cronCount int
+
+var cronCmd = &cobra.Command{Use: "cron", Short: "cron related utility functions"}
+
+var cronExplainCmd = &cobra.Command{
+	Use:   "explain",
+	Short: "explain a cron expression",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := cron.Explain(cronValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var cronNextCmd = &cobra.Command{
+	Use:   "next",
+	Short: "show the next matching times for a cron expression",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := cron.Next(cronValue, cronCount)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	cronExplainCmd.Flags().StringVar(&cronValue, "value", "", "input")
+	if err := cronExplainCmd.MarkFlagRequired("value"); err != nil {
+		panic("Please provide --value")
+	}
+	cronCmd.AddCommand(cronExplainCmd)
+
+	cronNextCmd.Flags().StringVar(&cronValue, "value", "", "input")
+	cronNextCmd.Flags().IntVar(&cronCount, "count", 5, "number of times to show")
+	if err := cronNextCmd.MarkFlagRequired("value"); err != nil {
+		panic("Please provide --value")
+	}
+	cronCmd.AddCommand(cronNextCmd)
+
+	rootCmd.AddCommand(cronCmd)
+}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/diff"
+
+	"github.com/spf13/cobra"
+)
+
+var diffA string
+var diffB string
+
+var diffCmd = &cobra.Command{
+	Use:   "diff",
+	Short: "compute a line-based diff between two inputs",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := diff.Lines(diffA, diffB)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	diffCmd.Flags().StringVar(&diffA, "a", "", "first input")
+	if err := diffCmd.MarkFlagRequired("a"); err != nil {
+		log.Fatalf("Please provide --a")
+	}
+	diffCmd.Flags().StringVar(&diffB, "b", "", "second input")
+	if err := diffCmd.MarkFlagRequired("b"); err != nil {
+		log.Fatalf("Please provide --b")
+	}
+	rootCmd.AddCommand(diffCmd)
+}

--- a/cmd/gzip.go
+++ b/cmd/gzip.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/gzip"
+
+	"github.com/spf13/cobra"
+)
+
+var gzipValue string
+
+var gzipCmd = &cobra.Command{Use: "gzip", Short: "gzip related utility functions"}
+
+var gzipCompressCmd = &cobra.Command{
+	Use:   "compress",
+	Short: "gzip-compresses the input and base64-encodes it",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := gzip.Compress(gzipValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var gzipDecompressCmd = &cobra.Command{
+	Use:   "decompress",
+	Short: "base64-decodes then gunzips the input",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := gzip.Decompress(gzipValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{gzipCompressCmd, gzipDecompressCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&gzipValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		gzipCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(gzipCmd)
+}

--- a/cmd/hash.go
+++ b/cmd/hash.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/hash"
+
+	"github.com/spf13/cobra"
+)
+
+var hashValue string
+
+var hashCmd = &cobra.Command{Use: "hash", Short: "hash related utility functions"}
+
+var hashMD5Cmd = &cobra.Command{
+	Use:   "md5",
+	Short: "computes the MD5 digest",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(hash.MD5(hashValue))
+		return nil
+	},
+}
+
+var hashSHA1Cmd = &cobra.Command{
+	Use:   "sha1",
+	Short: "computes the SHA-1 digest",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(hash.SHA1(hashValue))
+		return nil
+	},
+}
+
+var hashSHA256Cmd = &cobra.Command{
+	Use:   "sha256",
+	Short: "computes the SHA-256 digest",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(hash.SHA256(hashValue))
+		return nil
+	},
+}
+
+var hashSHA512Cmd = &cobra.Command{
+	Use:   "sha512",
+	Short: "computes the SHA-512 digest",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(hash.SHA512(hashValue))
+		return nil
+	},
+}
+
+var hashCRC32Cmd = &cobra.Command{
+	Use:   "crc32",
+	Short: "computes the IEEE CRC-32 checksum",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(hash.CRC32(hashValue))
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{hashMD5Cmd, hashSHA1Cmd, hashSHA256Cmd, hashSHA512Cmd, hashCRC32Cmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&hashValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		hashCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(hashCmd)
+}

--- a/cmd/hex.go
+++ b/cmd/hex.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/hex"
+
+	"github.com/spf13/cobra"
+)
+
+var hexValue string
+
+var hexCmd = &cobra.Command{Use: "hex", Short: "hex related utility functions"}
+
+var hexEncodeCmd = &cobra.Command{
+	Use:   "encode",
+	Short: "hex-encodes the input",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := hex.Encode(hexValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var hexDecodeCmd = &cobra.Command{
+	Use:   "decode",
+	Short: "hex-decodes the input",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := hex.Decode(hexValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{hexEncodeCmd, hexDecodeCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&hexValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		hexCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(hexCmd)
+}

--- a/cmd/html.go
+++ b/cmd/html.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/html"
+
+	"github.com/spf13/cobra"
+)
+
+var htmlValue string
+
+var htmlCmd = &cobra.Command{Use: "html", Short: "html related utility functions"}
+
+var htmlEscapeCmd = &cobra.Command{
+	Use:   "escape",
+	Short: "escape HTML special characters",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := html.Escape(htmlValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var htmlUnescapeCmd = &cobra.Command{
+	Use:   "unescape",
+	Short: "unescape HTML entities",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := html.Unescape(htmlValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var htmlStripCmd = &cobra.Command{
+	Use:   "strip",
+	Short: "strip HTML tags",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := html.Strip(htmlValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{htmlEscapeCmd, htmlUnescapeCmd, htmlStripCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&htmlValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		htmlCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(htmlCmd)
+}

--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"swiss/internal/ip"
+
+	"github.com/spf13/cobra"
+)
+
+var ipValue string
+
+var ipCmd = &cobra.Command{Use: "ip", Short: "ip related utility functions"}
+
+var ipCidrCmd = &cobra.Command{
+	Use:   "cidr",
+	Short: "report on a CIDR block",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := ip.CIDR(ipValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var ipToIntCmd = &cobra.Command{
+	Use:   "toInt",
+	Short: "convert IPv4 to integer",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := ip.ToInt(ipValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var ipFromIntCmd = &cobra.Command{
+	Use:   "fromInt",
+	Short: "convert integer to IPv4",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := ip.FromInt(ipValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{ipCidrCmd, ipToIntCmd, ipFromIntCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&ipValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			panic("Please provide --value")
+		}
+		ipCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(ipCmd)
+}

--- a/cmd/jq.go
+++ b/cmd/jq.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"os"
+	"swiss/internal/jq"
+
+	"github.com/alecthomas/chroma/quick"
+	"github.com/spf13/cobra"
+)
+
+var jqPath string
+var jqValue string
+
+var jqCmd = &cobra.Command{
+	Use:   "jq",
+	Short: "query json with a dot/index path",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := jq.Query(jqPath, jqValue)
+		if err != nil {
+			return err
+		}
+		return quick.Highlight(os.Stdout, res, "json", "terminal256", "monokai")
+	},
+}
+
+func init() {
+	jqCmd.Flags().StringVar(&jqPath, "path", "", "path")
+	jqCmd.Flags().StringVar(&jqValue, "value", "", "input")
+	if err := jqCmd.MarkFlagRequired("path"); err != nil {
+		panic("Please provide --path")
+	}
+	if err := jqCmd.MarkFlagRequired("value"); err != nil {
+		panic("Please provide --value")
+	}
+	rootCmd.AddCommand(jqCmd)
+}

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/jwt"
+
+	"github.com/spf13/cobra"
+)
+
+var jwtValue string
+var jwtSecret string
+
+var jwtCmd = &cobra.Command{Use: "jwt", Short: "jwt related utility functions"}
+
+var jwtDecodeCmd = &cobra.Command{
+	Use:   "decode",
+	Short: "decodes a JWT token",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := jwt.Decode(jwtValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var jwtVerifyCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "verifies a JWT HS256 signature",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := jwt.Verify(jwtValue, jwtSecret)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{jwtDecodeCmd, jwtVerifyCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&jwtValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		jwtCmd.AddCommand(c)
+	}
+	jwtVerifyCmd.Flags().StringVar(&jwtSecret, "secret", "", "secret")
+	if err := jwtVerifyCmd.MarkFlagRequired("secret"); err != nil {
+		log.Fatalf("Please provide --secret")
+	}
+	rootCmd.AddCommand(jwtCmd)
+}

--- a/cmd/lorem.go
+++ b/cmd/lorem.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+	"swiss/internal/lorem"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	loremWords      int
+	loremSentences  int
+	loremParagraphs int
+)
+
+var loremCmd = &cobra.Command{
+	Use:   "lorem",
+	Short: "generates lorem ipsum placeholder text",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if loremWords > 0 {
+			fmt.Println(lorem.Words(loremWords))
+		} else if loremSentences > 0 {
+			fmt.Println(lorem.Sentences(loremSentences))
+		} else {
+			fmt.Println(lorem.Paragraphs(loremParagraphs))
+		}
+		return nil
+	},
+}
+
+func init() {
+	loremCmd.Flags().IntVar(&loremWords, "words", 0, "number of words to generate")
+	loremCmd.Flags().IntVar(&loremSentences, "sentences", 0, "number of sentences to generate")
+	loremCmd.Flags().IntVar(&loremParagraphs, "paragraphs", 1, "number of paragraphs to generate")
+	rootCmd.AddCommand(loremCmd)
+}

--- a/cmd/regex.go
+++ b/cmd/regex.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/regex"
+
+	"github.com/spf13/cobra"
+)
+
+var regexPattern string
+var regexValue string
+var regexReplacement string
+
+var regexCmd = &cobra.Command{Use: "regex", Short: "regex related utility functions"}
+
+var regexMatchCmd = &cobra.Command{
+	Use:   "match",
+	Short: "find matches and capture groups",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := regex.Match(regexPattern, regexValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var regexReplaceCmd = &cobra.Command{
+	Use:   "replace",
+	Short: "replace matches with a replacement",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := regex.Replace(regexPattern, regexValue, regexReplacement)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	regexMatchCmd.Flags().StringVar(&regexPattern, "pattern", "", "regex pattern")
+	if err := regexMatchCmd.MarkFlagRequired("pattern"); err != nil {
+		log.Fatalf("Please provide --pattern")
+	}
+	regexMatchCmd.Flags().StringVar(&regexValue, "value", "", "input")
+	if err := regexMatchCmd.MarkFlagRequired("value"); err != nil {
+		log.Fatalf("Please provide --value")
+	}
+
+	regexReplaceCmd.Flags().StringVar(&regexPattern, "pattern", "", "regex pattern")
+	if err := regexReplaceCmd.MarkFlagRequired("pattern"); err != nil {
+		log.Fatalf("Please provide --pattern")
+	}
+	regexReplaceCmd.Flags().StringVar(&regexValue, "value", "", "input")
+	if err := regexReplaceCmd.MarkFlagRequired("value"); err != nil {
+		log.Fatalf("Please provide --value")
+	}
+	regexReplaceCmd.Flags().StringVar(&regexReplacement, "replacement", "", "replacement string")
+	if err := regexReplaceCmd.MarkFlagRequired("replacement"); err != nil {
+		log.Fatalf("Please provide --replacement")
+	}
+
+	regexCmd.AddCommand(regexMatchCmd)
+	regexCmd.AddCommand(regexReplaceCmd)
+	rootCmd.AddCommand(regexCmd)
+}

--- a/cmd/slug.go
+++ b/cmd/slug.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/slug"
+
+	"github.com/spf13/cobra"
+)
+
+var slugValue string
+
+var slugCmd = &cobra.Command{
+	Use:   "slug",
+	Short: "generates a URL-friendly slug from the input",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println(slug.Make(slugValue))
+		return nil
+	},
+}
+
+func init() {
+	slugCmd.Flags().StringVar(&slugValue, "value", "", "input")
+	if err := slugCmd.MarkFlagRequired("value"); err != nil {
+		log.Fatalf("Please provide --value")
+	}
+	rootCmd.AddCommand(slugCmd)
+}

--- a/cmd/sql.go
+++ b/cmd/sql.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"swiss/internal/sqlfmt"
+
+	"github.com/alecthomas/chroma/quick"
+	"github.com/spf13/cobra"
+)
+
+var sqlValue string
+
+var sqlCmd = &cobra.Command{Use: "sql", Short: "sql related utility functions"}
+
+var sqlFormatCmd = &cobra.Command{
+	Use:   "format",
+	Short: "format a SQL statement",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := sqlfmt.Format(sqlValue)
+		if err != nil {
+			return err
+		}
+		return quick.Highlight(os.Stdout, res, "sql", "terminal256", "monokai")
+	},
+}
+
+var sqlMinifyCmd = &cobra.Command{
+	Use:   "minify",
+	Short: "minify a SQL statement",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := sqlfmt.Minify(sqlValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{sqlFormatCmd, sqlMinifyCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&sqlValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		sqlCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(sqlCmd)
+}

--- a/cmd/text.go
+++ b/cmd/text.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/text"
+
+	"github.com/spf13/cobra"
+)
+
+var textValue string
+
+var textCmd = &cobra.Command{Use: "text", Short: "text related utility functions"}
+
+var textCountCmd = &cobra.Command{
+	Use:   "count",
+	Short: "counts characters, bytes, words, lines and reading time",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res := text.Count(textValue)
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{textCountCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&textValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		textCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(textCmd)
+}

--- a/cmd/time.go
+++ b/cmd/time.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/timeconv"
+
+	"github.com/spf13/cobra"
+)
+
+var timeValue string
+
+var timeCmd = &cobra.Command{Use: "time", Short: "time related utility functions"}
+
+var timeNowCmd = &cobra.Command{
+	Use:   "now",
+	Short: "prints the current time in several formats",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := timeconv.Now()
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var timeToUnixCmd = &cobra.Command{
+	Use:   "toUnix",
+	Short: "converts a date string to unix seconds",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := timeconv.ToUnix(timeValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var timeFromUnixCmd = &cobra.Command{
+	Use:   "fromUnix",
+	Short: "converts unix seconds to an RFC3339 UTC date",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := timeconv.FromUnix(timeValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	valueCommands := []*cobra.Command{timeToUnixCmd, timeFromUnixCmd}
+	for _, c := range valueCommands {
+		c.Flags().StringVar(&timeValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			log.Fatalf("Please provide --value")
+		}
+		timeCmd.AddCommand(c)
+	}
+	timeCmd.AddCommand(timeNowCmd)
+	rootCmd.AddCommand(timeCmd)
+}

--- a/cmd/toml.go
+++ b/cmd/toml.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"os"
+	"swiss/internal/toml"
+
+	"github.com/alecthomas/chroma/quick"
+	"github.com/spf13/cobra"
+)
+
+var tomlValue string
+
+var tomlCmd = &cobra.Command{Use: "toml", Short: "toml related utility functions"}
+
+var tomlToJSONCmd = &cobra.Command{
+	Use:   "toJSON",
+	Short: "convert toml to json",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := toml.ToJSON(tomlValue)
+		if err != nil {
+			return err
+		}
+		return quick.Highlight(os.Stdout, res, "json", "terminal256", "monokai")
+	},
+}
+
+var tomlToYAMLCmd = &cobra.Command{
+	Use:   "toYAML",
+	Short: "convert toml to yaml",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := toml.ToYAML(tomlValue)
+		if err != nil {
+			return err
+		}
+		return quick.Highlight(os.Stdout, res, "yaml", "terminal256", "monokai")
+	},
+}
+
+var tomlFromJSONCmd = &cobra.Command{
+	Use:   "fromJSON",
+	Short: "convert json to toml",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := toml.FromJSON(tomlValue)
+		if err != nil {
+			return err
+		}
+		return quick.Highlight(os.Stdout, res, "toml", "terminal256", "monokai")
+	},
+}
+
+func init() {
+	subCommands := []*cobra.Command{tomlToJSONCmd, tomlToYAMLCmd, tomlFromJSONCmd}
+	for _, c := range subCommands {
+		c.Flags().StringVar(&tomlValue, "value", "", "input")
+		if err := c.MarkFlagRequired("value"); err != nil {
+			panic("Please provide --value")
+		}
+		tomlCmd.AddCommand(c)
+	}
+	rootCmd.AddCommand(tomlCmd)
+}

--- a/cmd/uuid.go
+++ b/cmd/uuid.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"swiss/internal/uuid"
+
+	"github.com/spf13/cobra"
+)
+
+var uuidVersion int
+var uuidValue string
+
+var uuidCmd = &cobra.Command{Use: "uuid", Short: "uuid related utility functions"}
+
+var uuidGenCmd = &cobra.Command{
+	Use:   "gen",
+	Short: "generates a uuid (v4 or v7)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var (
+			res string
+			err error
+		)
+		switch uuidVersion {
+		case 4:
+			res, err = uuid.V4()
+		case 7:
+			res, err = uuid.V7()
+		default:
+			return fmt.Errorf("unsupported version %d (use 4 or 7)", uuidVersion)
+		}
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+var uuidValidateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "validates a uuid",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		res, err := uuid.Validate(uuidValue)
+		if err != nil {
+			return err
+		}
+		fmt.Println(res)
+		return nil
+	},
+}
+
+func init() {
+	uuidGenCmd.Flags().IntVar(&uuidVersion, "version", 4, "uuid version (4 or 7)")
+
+	uuidValidateCmd.Flags().StringVar(&uuidValue, "value", "", "uuid to validate")
+	if err := uuidValidateCmd.MarkFlagRequired("value"); err != nil {
+		log.Fatalf("Please provide --value")
+	}
+
+	uuidCmd.AddCommand(uuidGenCmd)
+	uuidCmd.AddCommand(uuidValidateCmd)
+	rootCmd.AddCommand(uuidCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module swiss
 go 1.26
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/alecthomas/chroma v0.10.0
 	github.com/basgys/goxml2json v1.1.0
 	github.com/spf13/cobra v1.6.1
+	golang.org/x/crypto v0.53.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -14,6 +16,6 @@ require (
 	github.com/dlclark/regexp2 v1.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/net v0.4.0 // indirect
-	golang.org/x/text v0.5.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/text v0.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
 github.com/basgys/goxml2json v1.1.0 h1:4ln5i4rseYfXNd86lGEB+Vi652IsIXIvggKM/BhUKVw=
@@ -24,10 +26,12 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/net v0.4.0 h1:Q5QPcMlvfxFTAPV0+07Xz/MpK9NTXu2VDUuy0FeMfaU=
-golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
-golang.org/x/text v0.5.0 h1:OLmvp0KP+FVG99Ct/qFiL/Fhk4zp4QQnZ7b2U+5piUM=
-golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
+golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
+golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/base58/base58.go
+++ b/internal/base58/base58.go
@@ -1,0 +1,76 @@
+package base58
+
+import (
+	"fmt"
+	"math/big"
+)
+
+const alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+var radix = big.NewInt(58)
+
+// Encode encodes the raw bytes of in using Bitcoin base58. It never returns an
+// error but keeps the signature for consistency.
+func Encode(in string) (string, error) {
+	data := []byte(in)
+
+	// Count leading zero bytes -> leading '1's.
+	zeros := 0
+	for zeros < len(data) && data[zeros] == 0 {
+		zeros++
+	}
+
+	num := new(big.Int).SetBytes(data)
+	mod := new(big.Int)
+	var out []byte
+	for num.Sign() > 0 {
+		num.DivMod(num, radix, mod)
+		out = append(out, alphabet[mod.Int64()])
+	}
+
+	for i := 0; i < zeros; i++ {
+		out = append(out, alphabet[0])
+	}
+
+	// Reverse.
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+
+	return string(out), nil
+}
+
+// Decode decodes a Bitcoin base58 string back into its raw bytes. It returns an
+// error when the input contains an invalid character.
+func Decode(in string) (string, error) {
+	// Count leading '1's -> leading zero bytes.
+	zeros := 0
+	for zeros < len(in) && in[zeros] == alphabet[0] {
+		zeros++
+	}
+
+	num := big.NewInt(0)
+	for i := 0; i < len(in); i++ {
+		idx := indexOf(in[i])
+		if idx < 0 {
+			return "", fmt.Errorf("invalid base58 character %q", in[i])
+		}
+		num.Mul(num, radix)
+		num.Add(num, big.NewInt(int64(idx)))
+	}
+
+	decoded := num.Bytes()
+	out := make([]byte, zeros+len(decoded))
+	copy(out[zeros:], decoded)
+
+	return string(out), nil
+}
+
+func indexOf(c byte) int {
+	for i := 0; i < len(alphabet); i++ {
+		if alphabet[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/base58/base58_test.go
+++ b/internal/base58/base58_test.go
@@ -1,0 +1,38 @@
+package base58
+
+import "testing"
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "simple", input: "hello"},
+		{name: "with spaces", input: "the quick brown fox"},
+		{name: "leading zero byte", input: "\x00abc"},
+		{name: "multiple leading zeros", input: "\x00\x00xy"},
+		{name: "empty", input: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enc, err := Encode(tt.input)
+			if err != nil {
+				t.Fatalf("Encode error: %v", err)
+			}
+			dec, err := Decode(enc)
+			if err != nil {
+				t.Fatalf("Decode error: %v", err)
+			}
+			if dec != tt.input {
+				t.Fatalf("round trip mismatch: got %q, want %q", dec, tt.input)
+			}
+		})
+	}
+}
+
+func TestDecodeInvalid(t *testing.T) {
+	if _, err := Decode("0OIl"); err == nil {
+		t.Fatalf("expected error for invalid base58 input, got nil")
+	}
+}

--- a/internal/bcrypt/bcrypt.go
+++ b/internal/bcrypt/bcrypt.go
@@ -1,0 +1,27 @@
+package bcrypt
+
+import (
+	gobcrypt "golang.org/x/crypto/bcrypt"
+)
+
+// Hash returns a bcrypt hash of the given password.
+func Hash(password string) (string, error) {
+	h, err := gobcrypt.GenerateFromPassword([]byte(password), gobcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(h), nil
+}
+
+// Verify compares a bcrypt hash against a password. It returns "match" or
+// "no match". An error is only returned when the hash is malformed.
+func Verify(hash, password string) (string, error) {
+	err := gobcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+	if err == nil {
+		return "match", nil
+	}
+	if err == gobcrypt.ErrMismatchedHashAndPassword {
+		return "no match", nil
+	}
+	return "", err
+}

--- a/internal/bcrypt/bcrypt_test.go
+++ b/internal/bcrypt/bcrypt_test.go
@@ -1,0 +1,40 @@
+package bcrypt
+
+import "testing"
+
+func TestVerify(t *testing.T) {
+	hash, err := Hash("s3cret")
+	if err != nil {
+		t.Fatalf("Hash returned error: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		hash     string
+		password string
+		want     string
+		wantErr  bool
+	}{
+		{name: "match", hash: hash, password: "s3cret", want: "match"},
+		{name: "no match", hash: hash, password: "wrong", want: "no match"},
+		{name: "malformed hash", hash: "not-a-hash", password: "s3cret", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Verify(tt.hash, tt.password)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cert/cert.go
+++ b/internal/cert/cert.go
@@ -1,0 +1,33 @@
+package cert
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Info parses a PEM-encoded X.509 certificate and returns a multi-line summary.
+func Info(pemStr string) (string, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return "", fmt.Errorf("failed to decode PEM data")
+	}
+
+	c, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Subject: %s\n", c.Subject.String())
+	fmt.Fprintf(&b, "Issuer: %s\n", c.Issuer.String())
+	fmt.Fprintf(&b, "Serial: %s\n", c.SerialNumber.String())
+	fmt.Fprintf(&b, "Not Before: %s\n", c.NotBefore.Format(time.RFC3339))
+	fmt.Fprintf(&b, "Not After: %s\n", c.NotAfter.Format(time.RFC3339))
+	fmt.Fprintf(&b, "DNS SANs: %s\n", strings.Join(c.DNSNames, ", "))
+	fmt.Fprintf(&b, "IsCA: %t", c.IsCA)
+
+	return b.String(), nil
+}

--- a/internal/cert/cert_test.go
+++ b/internal/cert/cert_test.go
@@ -1,0 +1,51 @@
+package cert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInfo(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey error: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1234),
+		Subject:      pkix.Name{CommonName: "swiss.example.com"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"swiss.example.com"},
+		IsCA:         true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate error: %v", err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	out, err := Info(string(pemBytes))
+	if err != nil {
+		t.Fatalf("Info error: %v", err)
+	}
+	if !strings.Contains(out, "swiss.example.com") {
+		t.Fatalf("output does not contain subject CN: %q", out)
+	}
+}
+
+func TestInfoInvalid(t *testing.T) {
+	if _, err := Info("garbage"); err == nil {
+		t.Fatalf("expected error for invalid PEM input, got nil")
+	}
+}

--- a/internal/color/color.go
+++ b/internal/color/color.go
@@ -1,0 +1,111 @@
+package color
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// ToRGB parses a hex color and returns "rgb(r, g, b)".
+func ToRGB(in string) (string, error) {
+	r, g, b, err := parseHex(in)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("rgb(%d, %d, %d)", r, g, b), nil
+}
+
+// ToHex parses "rgb(r, g, b)" or "r,g,b" and returns "#rrggbb".
+func ToHex(in string) (string, error) {
+	s := strings.TrimSpace(in)
+	s = strings.TrimPrefix(s, "rgb(")
+	s = strings.TrimPrefix(s, "rgba(")
+	s = strings.TrimSuffix(s, ")")
+	parts := strings.Split(s, ",")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("invalid rgb input: %q", in)
+	}
+	vals := make([]int, 3)
+	for i, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil {
+			return "", fmt.Errorf("invalid rgb component %q: %w", p, err)
+		}
+		if n < 0 || n > 255 {
+			return "", fmt.Errorf("rgb component out of range: %d", n)
+		}
+		vals[i] = n
+	}
+	return fmt.Sprintf("#%02x%02x%02x", vals[0], vals[1], vals[2]), nil
+}
+
+// ToHSL parses a hex color and returns "hsl(h, s%, l%)".
+func ToHSL(in string) (string, error) {
+	ri, gi, bi, err := parseHex(in)
+	if err != nil {
+		return "", err
+	}
+	r := float64(ri) / 255.0
+	g := float64(gi) / 255.0
+	b := float64(bi) / 255.0
+
+	max := math.Max(r, math.Max(g, b))
+	min := math.Min(r, math.Min(g, b))
+	l := (max + min) / 2.0
+
+	var h, s float64
+	if max == min {
+		h = 0
+		s = 0
+	} else {
+		d := max - min
+		if l > 0.5 {
+			s = d / (2.0 - max - min)
+		} else {
+			s = d / (max + min)
+		}
+		switch max {
+		case r:
+			h = (g - b) / d
+			if g < b {
+				h += 6
+			}
+		case g:
+			h = (b-r)/d + 2
+		case b:
+			h = (r-g)/d + 4
+		}
+		h /= 6
+	}
+
+	hDeg := math.Round(h * 360)
+	sPct := math.Round(s * 100)
+	lPct := math.Round(l * 100)
+	return fmt.Sprintf("hsl(%d, %d%%, %d%%)", int(hDeg), int(sPct), int(lPct)), nil
+}
+
+func parseHex(in string) (int, int, int, error) {
+	s := strings.TrimSpace(in)
+	s = strings.TrimPrefix(s, "#")
+	s = strings.ToLower(s)
+	if len(s) == 3 {
+		s = string([]byte{s[0], s[0], s[1], s[1], s[2], s[2]})
+	}
+	if len(s) != 6 {
+		return 0, 0, 0, fmt.Errorf("invalid hex color: %q", in)
+	}
+	r, err := strconv.ParseInt(s[0:2], 16, 0)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid hex color: %q", in)
+	}
+	g, err := strconv.ParseInt(s[2:4], 16, 0)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid hex color: %q", in)
+	}
+	b, err := strconv.ParseInt(s[4:6], 16, 0)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid hex color: %q", in)
+	}
+	return int(r), int(g), int(b), nil
+}

--- a/internal/color/color_test.go
+++ b/internal/color/color_test.go
@@ -1,0 +1,80 @@
+package color
+
+import "testing"
+
+func TestToRGB(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"white", "#ffffff", "rgb(255, 255, 255)", false},
+		{"shorthand", "#fff", "rgb(255, 255, 255)", false},
+		{"no hash", "ff0000", "rgb(255, 0, 0)", false},
+		{"invalid", "#zzz", "", true},
+		{"bad length", "#ff", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToRGB(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ToRGB(%q) err=%v wantErr=%v", tt.in, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ToRGB(%q)=%q want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToHex(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"red rgb", "rgb(255,0,0)", "#ff0000", false},
+		{"plain", "0,255,0", "#00ff00", false},
+		{"out of range", "rgb(256,0,0)", "", true},
+		{"invalid", "rgb(a,b,c)", "", true},
+		{"too few", "1,2", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToHex(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ToHex(%q) err=%v wantErr=%v", tt.in, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ToHex(%q)=%q want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToHSL(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"white", "#ffffff", "hsl(0, 0%, 100%)", false},
+		{"black", "#000000", "hsl(0, 0%, 0%)", false},
+		{"red", "#ff0000", "hsl(0, 100%, 50%)", false},
+		{"invalid", "nope", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToHSL(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ToHSL(%q) err=%v wantErr=%v", tt.in, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ToHSL(%q)=%q want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cron/cron.go
+++ b/internal/cron/cron.go
@@ -1,0 +1,181 @@
+package cron
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type fieldSpec struct {
+	name   string
+	min    int
+	max    int
+	values map[int]bool
+	star   bool
+	step   int // 0 if not a pure */n
+}
+
+var fieldDefs = []struct {
+	name string
+	min  int
+	max  int
+}{
+	{"Minute", 0, 59},
+	{"Hour", 0, 23},
+	{"Day of month", 1, 31},
+	{"Month", 1, 12},
+	{"Day of week", 0, 6},
+}
+
+func parse(expr string) ([]fieldSpec, error) {
+	parts := strings.Fields(strings.TrimSpace(expr))
+	if len(parts) != 5 {
+		return nil, fmt.Errorf("expected 5 fields, got %d", len(parts))
+	}
+	specs := make([]fieldSpec, 5)
+	for i, p := range parts {
+		def := fieldDefs[i]
+		fs, err := parseField(p, def.name, def.min, def.max)
+		if err != nil {
+			return nil, err
+		}
+		specs[i] = fs
+	}
+	return specs, nil
+}
+
+func parseField(s, name string, min, max int) (fieldSpec, error) {
+	fs := fieldSpec{name: name, min: min, max: max, values: map[int]bool{}}
+	for _, token := range strings.Split(s, ",") {
+		if err := parseToken(token, &fs); err != nil {
+			return fs, err
+		}
+	}
+	return fs, nil
+}
+
+func parseToken(token string, fs *fieldSpec) error {
+	step := 1
+	rangePart := token
+	if idx := strings.IndexByte(token, '/'); idx >= 0 {
+		rangePart = token[:idx]
+		stepStr := token[idx+1:]
+		n, err := strconv.Atoi(stepStr)
+		if err != nil || n <= 0 {
+			return fmt.Errorf("%s: invalid step %q", fs.name, stepStr)
+		}
+		step = n
+	}
+
+	var lo, hi int
+	if rangePart == "*" {
+		lo, hi = fs.min, fs.max
+		if step != 1 {
+			fs.step = step
+		} else {
+			fs.star = true
+		}
+	} else if dash := strings.IndexByte(rangePart, '-'); dash >= 0 {
+		a, err := strconv.Atoi(rangePart[:dash])
+		if err != nil {
+			return fmt.Errorf("%s: invalid value %q", fs.name, rangePart[:dash])
+		}
+		b, err := strconv.Atoi(rangePart[dash+1:])
+		if err != nil {
+			return fmt.Errorf("%s: invalid value %q", fs.name, rangePart[dash+1:])
+		}
+		lo, hi = a, b
+	} else {
+		v, err := strconv.Atoi(rangePart)
+		if err != nil {
+			return fmt.Errorf("%s: invalid value %q", fs.name, rangePart)
+		}
+		lo, hi = v, v
+	}
+
+	if lo < fs.min || hi > fs.max || lo > hi {
+		return fmt.Errorf("%s: value out of range %d-%d", fs.name, fs.min, fs.max)
+	}
+	for v := lo; v <= hi; v += step {
+		fs.values[v] = true
+	}
+	return nil
+}
+
+func (fs fieldSpec) matches(v int) bool {
+	if fs.star {
+		return true
+	}
+	if fs.step > 0 {
+		return (v-fs.min)%fs.step == 0
+	}
+	return fs.values[v]
+}
+
+func (fs fieldSpec) describe() string {
+	if fs.star {
+		return "every"
+	}
+	if fs.step > 0 {
+		return fmt.Sprintf("every %d", fs.step)
+	}
+	vals := make([]int, 0, len(fs.values))
+	for v := fs.min; v <= fs.max; v++ {
+		if fs.values[v] {
+			vals = append(vals, v)
+		}
+	}
+	parts := make([]string, len(vals))
+	for i, v := range vals {
+		parts[i] = strconv.Itoa(v)
+	}
+	return "at " + strings.Join(parts, ",")
+}
+
+// Explain returns a human-readable, field-by-field description of a cron expression.
+func Explain(expr string) (string, error) {
+	specs, err := parse(expr)
+	if err != nil {
+		return "", err
+	}
+	lines := make([]string, len(specs))
+	for i, fs := range specs {
+		lines[i] = fmt.Sprintf("%s: %s", fs.name, fs.describe())
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+// Next returns the next count times (from now) that match the cron expression,
+// formatted as RFC3339 lines.
+func Next(expr string, count int) (string, error) {
+	specs, err := parse(expr)
+	if err != nil {
+		return "", err
+	}
+	if count <= 0 {
+		return "", fmt.Errorf("count must be positive")
+	}
+
+	t := time.Now().Truncate(time.Minute).Add(time.Minute)
+	var results []string
+	maxIter := 525600 * 2
+	for i := 0; i < maxIter && len(results) < count; i++ {
+		if matchTime(specs, t) {
+			results = append(results, t.Format(time.RFC3339))
+		}
+		t = t.Add(time.Minute)
+	}
+	if len(results) < count {
+		return "", fmt.Errorf("could not find %d matches within search window", count)
+	}
+	return strings.Join(results, "\n"), nil
+}
+
+func matchTime(specs []fieldSpec, t time.Time) bool {
+	return specs[0].matches(t.Minute()) &&
+		specs[1].matches(t.Hour()) &&
+		specs[2].matches(t.Day()) &&
+		specs[3].matches(int(t.Month())) &&
+		specs[4].matches(int(t.Weekday()))
+}

--- a/internal/cron/cron_test.go
+++ b/internal/cron/cron_test.go
@@ -1,0 +1,61 @@
+package cron
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExplain(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		want    string
+		wantErr bool
+	}{
+		{"every 5", "*/5 * * * *", "5", false},
+		{"wrong count", "a b c", "", true},
+		{"out of range", "99 * * * *", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Explain(tt.expr)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Explain() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("Explain() = %q, want contains %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNext(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		count   int
+		want    int
+		wantErr bool
+	}{
+		{"every minute", "* * * * *", 3, 3, false},
+		{"bad expr", "a b c", 3, 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Next(tt.expr, tt.count)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Next() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			lines := strings.Split(strings.TrimSpace(got), "\n")
+			if len(lines) != tt.want {
+				t.Errorf("Next() returned %d lines, want %d", len(lines), tt.want)
+			}
+		})
+	}
+}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,57 @@
+package diff
+
+import "strings"
+
+// Lines computes a line-based diff using a standard LCS dynamic-programming
+// algorithm. Unchanged lines are prefixed with "  ", deletions with "- ",
+// and additions with "+ ".
+func Lines(a, b string) (string, error) {
+	aLines := strings.Split(a, "\n")
+	bLines := strings.Split(b, "\n")
+
+	n := len(aLines)
+	m := len(bLines)
+
+	// LCS length table.
+	lcs := make([][]int, n+1)
+	for i := range lcs {
+		lcs[i] = make([]int, m+1)
+	}
+	for i := n - 1; i >= 0; i-- {
+		for j := m - 1; j >= 0; j-- {
+			if aLines[i] == bLines[j] {
+				lcs[i][j] = lcs[i+1][j+1] + 1
+			} else if lcs[i+1][j] >= lcs[i][j+1] {
+				lcs[i][j] = lcs[i+1][j]
+			} else {
+				lcs[i][j] = lcs[i][j+1]
+			}
+		}
+	}
+
+	var sb strings.Builder
+	i, j := 0, 0
+	for i < n && j < m {
+		if aLines[i] == bLines[j] {
+			sb.WriteString("  " + aLines[i] + "\n")
+			i++
+			j++
+		} else if lcs[i+1][j] >= lcs[i][j+1] {
+			sb.WriteString("- " + aLines[i] + "\n")
+			i++
+		} else {
+			sb.WriteString("+ " + bLines[j] + "\n")
+			j++
+		}
+	}
+	for i < n {
+		sb.WriteString("- " + aLines[i] + "\n")
+		i++
+	}
+	for j < m {
+		sb.WriteString("+ " + bLines[j] + "\n")
+		j++
+	}
+
+	return strings.TrimRight(sb.String(), "\n"), nil
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,54 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLines(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        string
+		b        string
+		contains []string
+	}{
+		{
+			name:     "single change",
+			a:        "x\ny\nz",
+			b:        "x\nY\nz",
+			contains: []string{"  x", "- y", "+ Y", "  z"},
+		},
+		{
+			name:     "identical",
+			a:        "a\nb",
+			b:        "a\nb",
+			contains: []string{"  a", "  b"},
+		},
+		{
+			name:     "addition",
+			a:        "a",
+			b:        "a\nb",
+			contains: []string{"  a", "+ b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := Lines(tt.a, tt.b)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			lastIdx := -1
+			for _, c := range tt.contains {
+				idx := strings.Index(res, c)
+				if idx < 0 {
+					t.Fatalf("expected %q in output:\n%s", c, res)
+				}
+				if idx < lastIdx {
+					t.Fatalf("expected %q after previous marker, output:\n%s", c, res)
+				}
+				lastIdx = idx
+			}
+		})
+	}
+}

--- a/internal/gzip/gzip.go
+++ b/internal/gzip/gzip.go
@@ -1,0 +1,41 @@
+package gzip
+
+import (
+	"bytes"
+	gz "compress/gzip"
+	"encoding/base64"
+	"io"
+)
+
+// Compress gzip-compresses the input bytes and returns the result as a
+// standard base64-encoded string.
+func Compress(in string) (string, error) {
+	var buf bytes.Buffer
+	w := gz.NewWriter(&buf)
+	if _, err := w.Write([]byte(in)); err != nil {
+		return "", err
+	}
+	if err := w.Close(); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+// Decompress base64-decodes the input then gunzips it, returning the
+// original text.
+func Decompress(in string) (string, error) {
+	data, err := base64.StdEncoding.DecodeString(in)
+	if err != nil {
+		return "", err
+	}
+	r, err := gz.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+	out, err := io.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/internal/gzip/gzip_test.go
+++ b/internal/gzip/gzip_test.go
@@ -1,0 +1,46 @@
+package gzip
+
+import "testing"
+
+func TestRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"simple", "hello world"},
+		{"empty", ""},
+		{"unicode", "héllo, wörld"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := Compress(tt.in)
+			if err != nil {
+				t.Fatalf("Compress() unexpected error = %v", err)
+			}
+			got, err := Decompress(c)
+			if err != nil {
+				t.Fatalf("Decompress() unexpected error = %v", err)
+			}
+			if got != tt.in {
+				t.Errorf("round trip = %q, want %q", got, tt.in)
+			}
+		})
+	}
+}
+
+func TestDecompressError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"bad base64", "!!!not base64!!!"},
+		{"valid base64 not gzip", "aGVsbG8="},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := Decompress(tt.in); err == nil {
+				t.Errorf("Decompress(%q) expected error, got nil", tt.in)
+			}
+		})
+	}
+}

--- a/internal/hash/hash.go
+++ b/internal/hash/hash.go
@@ -1,0 +1,41 @@
+package hash
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"hash/crc32"
+)
+
+// MD5 returns the hex-encoded MD5 digest of the input.
+func MD5(in string) string {
+	sum := md5.Sum([]byte(in))
+	return hex.EncodeToString(sum[:])
+}
+
+// SHA1 returns the hex-encoded SHA-1 digest of the input.
+func SHA1(in string) string {
+	sum := sha1.Sum([]byte(in))
+	return hex.EncodeToString(sum[:])
+}
+
+// SHA256 returns the hex-encoded SHA-256 digest of the input.
+func SHA256(in string) string {
+	sum := sha256.Sum256([]byte(in))
+	return hex.EncodeToString(sum[:])
+}
+
+// SHA512 returns the hex-encoded SHA-512 digest of the input.
+func SHA512(in string) string {
+	sum := sha512.Sum512([]byte(in))
+	return hex.EncodeToString(sum[:])
+}
+
+// CRC32 returns the hex-encoded IEEE CRC-32 checksum of the input.
+func CRC32(in string) string {
+	sum := crc32.ChecksumIEEE([]byte(in))
+	return fmt.Sprintf("%08x", sum)
+}

--- a/internal/hash/hash_test.go
+++ b/internal/hash/hash_test.go
@@ -1,0 +1,34 @@
+package hash
+
+import "testing"
+
+func TestHashes(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(string) string
+		in   string
+		want string
+	}{
+		{"md5", MD5, "abc", "900150983cd24fb0d6963f7d28e17f72"},
+		{"sha1", SHA1, "abc", "a9993e364706816aba3e25717850c26c9cd0d89d"},
+		{"sha256", SHA256, "abc", "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"},
+		{"sha512", SHA512, "abc", "ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"},
+		{"crc32", CRC32, "abc", "352441c2"},
+		{"md5 empty", MD5, "", "d41d8cd98f00b204e9800998ecf8427e"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fn(tt.in); got != tt.want {
+				t.Errorf("%s(%q) = %q, want %q", tt.name, tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCRC32Error(t *testing.T) {
+	// CRC32 should never collide for these distinct, simple inputs.
+	if CRC32("abc") == CRC32("abd") {
+		t.Errorf("CRC32 unexpectedly equal for distinct inputs")
+	}
+}

--- a/internal/hex/hex.go
+++ b/internal/hex/hex.go
@@ -1,0 +1,20 @@
+package hex
+
+import (
+	stdhex "encoding/hex"
+)
+
+// Encode hex-encodes the input string. The error return is kept for
+// uniformity and is always nil.
+func Encode(in string) (string, error) {
+	return stdhex.EncodeToString([]byte(in)), nil
+}
+
+// Decode hex-decodes the input string and returns the resulting text.
+func Decode(in string) (string, error) {
+	b, err := stdhex.DecodeString(in)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/hex/hex_test.go
+++ b/internal/hex/hex_test.go
@@ -1,0 +1,52 @@
+package hex
+
+import "testing"
+
+func TestEncode(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"simple", "abc", "616263"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Encode(tt.in)
+			if err != nil {
+				t.Fatalf("Encode() unexpected error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Encode(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"simple", "616263", "abc", false},
+		{"empty", "", "", false},
+		{"bad hex", "xyz", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Decode(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Decode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Decode(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/html/html.go
+++ b/internal/html/html.go
@@ -1,0 +1,23 @@
+package html
+
+import (
+	stdhtml "html"
+	"regexp"
+)
+
+var tagRe = regexp.MustCompile(`<[^>]*>`)
+
+// Escape converts special characters to their HTML entity equivalents.
+func Escape(in string) (string, error) {
+	return stdhtml.EscapeString(in), nil
+}
+
+// Unescape converts HTML entities back to their plain characters.
+func Unescape(in string) (string, error) {
+	return stdhtml.UnescapeString(in), nil
+}
+
+// Strip removes HTML tags from the input.
+func Strip(in string) (string, error) {
+	return tagRe.ReplaceAllString(in, ""), nil
+}

--- a/internal/html/html_test.go
+++ b/internal/html/html_test.go
@@ -1,0 +1,51 @@
+package html
+
+import "testing"
+
+func TestEscapeUnescapeRoundTrip(t *testing.T) {
+	tests := []string{
+		`<a href="x">link</a>`,
+		`a & b < c > d`,
+		`plain text`,
+	}
+
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			esc, err := Escape(in)
+			if err != nil {
+				t.Fatalf("escape error: %v", err)
+			}
+			out, err := Unescape(esc)
+			if err != nil {
+				t.Fatalf("unescape error: %v", err)
+			}
+			if out != in {
+				t.Fatalf("round-trip failed: got %q, want %q", out, in)
+			}
+		})
+	}
+}
+
+func TestStrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"anchor", `<a href="x">link</a>`, "link"},
+		{"nested", `<p><b>hi</b></p>`, "hi"},
+		{"no tags", "plain", "plain"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := Strip(tt.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res != tt.want {
+				t.Fatalf("got %q, want %q", res, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ip/ip.go
+++ b/internal/ip/ip.go
@@ -1,0 +1,81 @@
+package ip
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// CIDR parses a CIDR and returns a human-readable report.
+func CIDR(in string) (string, error) {
+	ip, ipNet, err := net.ParseCIDR(in)
+	if err != nil {
+		return "", err
+	}
+	ones, bits := ipNet.Mask.Size()
+	hostBits := bits - ones
+
+	count := new(big.Int).Lsh(big.NewInt(1), uint(hostBits))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Network address: %s\n", ipNet.IP.String())
+	fmt.Fprintf(&b, "Netmask: %s\n", maskString(ipNet.Mask))
+	fmt.Fprintf(&b, "Prefix length: %d\n", ones)
+	fmt.Fprintf(&b, "Number of addresses: %s\n", count.String())
+
+	if v4 := ipNet.IP.To4(); v4 != nil {
+		network := binary.BigEndian.Uint32(v4)
+		mask := binary.BigEndian.Uint32(net.IP(ipNet.Mask).To4())
+		broadcast := network | ^mask
+		first := network
+		last := broadcast
+		if hostBits >= 2 {
+			first = network + 1
+			last = broadcast - 1
+		}
+		fmt.Fprintf(&b, "First host: %s\n", uint32ToIP(first))
+		fmt.Fprintf(&b, "Last host: %s\n", uint32ToIP(last))
+		fmt.Fprintf(&b, "Broadcast: %s\n", uint32ToIP(broadcast))
+	}
+	_ = ip
+	return strings.TrimRight(b.String(), "\n"), nil
+}
+
+func maskString(m net.IPMask) string {
+	if len(m) == 4 {
+		return fmt.Sprintf("%d.%d.%d.%d", m[0], m[1], m[2], m[3])
+	}
+	return m.String()
+}
+
+func uint32ToIP(v uint32) string {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, v)
+	return net.IP(b).String()
+}
+
+// ToInt parses an IPv4 address and returns its uint32 value as a decimal string.
+func ToInt(in string) (string, error) {
+	ip := net.ParseIP(strings.TrimSpace(in))
+	if ip == nil {
+		return "", errors.New("invalid IP address")
+	}
+	v4 := ip.To4()
+	if v4 == nil {
+		return "", errors.New("not an IPv4 address")
+	}
+	return strconv.FormatUint(uint64(binary.BigEndian.Uint32(v4)), 10), nil
+}
+
+// FromInt parses a decimal uint32 and returns the dotted IPv4 address.
+func FromInt(in string) (string, error) {
+	n, err := strconv.ParseUint(strings.TrimSpace(in), 10, 32)
+	if err != nil {
+		return "", err
+	}
+	return uint32ToIP(uint32(n)), nil
+}

--- a/internal/ip/ip_test.go
+++ b/internal/ip/ip_test.go
@@ -1,0 +1,57 @@
+package ip
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCIDR(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"v4", "192.168.1.0/24", "192.168.1.255", false},
+		{"invalid", "not-a-cidr", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CIDR(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CIDR() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("CIDR() = %q, want contains %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	tests := []string{"10.0.0.1", "192.168.1.1", "0.0.0.0", "255.255.255.255"}
+	for _, ip := range tests {
+		t.Run(ip, func(t *testing.T) {
+			n, err := ToInt(ip)
+			if err != nil {
+				t.Fatalf("ToInt() error = %v", err)
+			}
+			back, err := FromInt(n)
+			if err != nil {
+				t.Fatalf("FromInt() error = %v", err)
+			}
+			if back != ip {
+				t.Errorf("round trip = %q, want %q", back, ip)
+			}
+		})
+	}
+}
+
+func TestToIntErrors(t *testing.T) {
+	if _, err := ToInt("not-an-ip"); err == nil {
+		t.Errorf("expected error for invalid IP")
+	}
+}

--- a/internal/jq/jq.go
+++ b/internal/jq/jq.go
@@ -1,0 +1,96 @@
+package jq
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type step struct {
+	key   string
+	index int
+	isKey bool
+}
+
+func tokenize(path string) ([]step, error) {
+	path = strings.TrimPrefix(path, ".")
+	var steps []step
+	if path == "" {
+		return steps, nil
+	}
+	parts := strings.Split(path, ".")
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		// Split off any trailing [n] indices.
+		name := part
+		if i := strings.IndexByte(part, '['); i >= 0 {
+			name = part[:i]
+		}
+		if name != "" {
+			steps = append(steps, step{key: name, isKey: true})
+		}
+		rest := part[len(name):]
+		for len(rest) > 0 {
+			if rest[0] != '[' {
+				return nil, fmt.Errorf("invalid path segment: %q", part)
+			}
+			end := strings.IndexByte(rest, ']')
+			if end < 0 {
+				return nil, fmt.Errorf("invalid path segment: %q", part)
+			}
+			idxStr := rest[1:end]
+			idx, err := strconv.Atoi(idxStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid index: %q", idxStr)
+			}
+			steps = append(steps, step{index: idx, isKey: false})
+			rest = rest[end+1:]
+		}
+	}
+	return steps, nil
+}
+
+// Query parses value as JSON and walks the given path, returning the
+// resulting sub-value re-marshalled as indented JSON.
+func Query(path, value string) (string, error) {
+	var data interface{}
+	if err := json.Unmarshal([]byte(value), &data); err != nil {
+		return "", err
+	}
+	steps, err := tokenize(path)
+	if err != nil {
+		return "", err
+	}
+	cur := data
+	for _, s := range steps {
+		if s.isKey {
+			m, ok := cur.(map[string]interface{})
+			if !ok {
+				return "", errors.New("path not found")
+			}
+			v, ok := m[s.key]
+			if !ok {
+				return "", errors.New("path not found")
+			}
+			cur = v
+		} else {
+			arr, ok := cur.([]interface{})
+			if !ok {
+				return "", errors.New("path not found")
+			}
+			if s.index < 0 || s.index >= len(arr) {
+				return "", errors.New("path not found")
+			}
+			cur = arr[s.index]
+		}
+	}
+	b, err := json.MarshalIndent(cur, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/jq/jq_test.go
+++ b/internal/jq/jq_test.go
@@ -1,0 +1,34 @@
+package jq
+
+import "testing"
+
+func TestQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		value   string
+		want    string
+		wantErr bool
+	}{
+		{"array index", "a.b[1]", `{"a":{"b":[10,20]}}`, "20", false},
+		{"leading dot", ".a", `{"a":5}`, "5", false},
+		{"nested", "items[2]", `{"items":[1,2,3]}`, "3", false},
+		{"missing key", "a.c", `{"a":{"b":1}}`, "", true},
+		{"out of range", "a[5]", `{"a":[1,2]}`, "", true},
+		{"type mismatch", "a.b", `{"a":[1,2]}`, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Query(tt.path, tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Query() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Query() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/jwt/jwt.go
+++ b/internal/jwt/jwt.go
@@ -1,0 +1,94 @@
+package jwt
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func decodeSegment(seg string) ([]byte, error) {
+	return base64.RawURLEncoding.DecodeString(strings.TrimRight(seg, "="))
+}
+
+func prettyJSON(data []byte) (string, error) {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// Decode splits a JWT, base64url-decodes the header and payload, and
+// pretty-prints them as indented JSON. If the payload has a numeric "exp"
+// claim, the expiration time is appended in RFC3339 format.
+func Decode(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", errors.New("invalid token: expected 3 parts")
+	}
+
+	headerRaw, err := decodeSegment(parts[0])
+	if err != nil {
+		return "", err
+	}
+	payloadRaw, err := decodeSegment(parts[1])
+	if err != nil {
+		return "", err
+	}
+
+	headerJSON, err := prettyJSON(headerRaw)
+	if err != nil {
+		return "", err
+	}
+	payloadJSON, err := prettyJSON(payloadRaw)
+	if err != nil {
+		return "", err
+	}
+
+	res := fmt.Sprintf("Header:\n%s\n\nPayload:\n%s", headerJSON, payloadJSON)
+
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payloadRaw, &claims); err == nil {
+		if exp, ok := claims["exp"]; ok {
+			if expF, ok := exp.(float64); ok {
+				t := time.Unix(int64(expF), 0).UTC()
+				res += fmt.Sprintf("\n\nExpires: %s", t.Format(time.RFC3339))
+			}
+		}
+	}
+
+	return res, nil
+}
+
+// Verify checks the HS256 signature of a JWT against the given secret.
+// It returns "valid" or "invalid"; an error is only returned for a
+// malformed token.
+func Verify(token, secret string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return "", errors.New("invalid token: expected 3 parts")
+	}
+
+	sig, err := decodeSegment(parts[2])
+	if err != nil {
+		return "", err
+	}
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(parts[0] + "." + parts[1]))
+	expected := mac.Sum(nil)
+
+	if hmac.Equal(sig, expected) {
+		return "valid", nil
+	}
+	return "invalid", nil
+}

--- a/internal/jwt/jwt_test.go
+++ b/internal/jwt/jwt_test.go
@@ -1,0 +1,116 @@
+package jwt
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// sign builds an HS256 JWT from a header/payload/secret so the test never
+// depends on a hand-computed signature.
+func sign(header, payload, secret string) string {
+	h := base64.RawURLEncoding.EncodeToString([]byte(header))
+	p := base64.RawURLEncoding.EncodeToString([]byte(payload))
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(h + "." + p))
+	s := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return h + "." + p + "." + s
+}
+
+const (
+	sampleHeader  = `{"alg":"HS256","typ":"JWT"}`
+	samplePayload = `{"sub":"1234567890","name":"John Doe","exp":2000000000}`
+)
+
+func sampleToken() string {
+	return sign(sampleHeader, samplePayload, "secret")
+}
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		name      string
+		token     string
+		wantErr   bool
+		wantParts []string
+	}{
+		{
+			name:      "valid token",
+			token:     sampleToken(),
+			wantErr:   false,
+			wantParts: []string{"Header:", "Payload:", "John Doe", "Expires:"},
+		},
+		{
+			name:    "wrong number of parts",
+			token:   "a.b",
+			wantErr: true,
+		},
+		{
+			name:    "bad base64",
+			token:   "!!!.!!!.!!!",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Decode(tt.token)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Decode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			for _, p := range tt.wantParts {
+				if !strings.Contains(got, p) {
+					t.Errorf("Decode() = %q, missing %q", got, p)
+				}
+			}
+		})
+	}
+}
+
+func TestVerify(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		secret  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "valid signature",
+			token:  sampleToken(),
+			secret: "secret",
+			want:   "valid",
+		},
+		{
+			name:   "invalid signature",
+			token:  sampleToken(),
+			secret: "wrong",
+			want:   "invalid",
+		},
+		{
+			name:    "malformed token",
+			token:   "a.b",
+			secret:  "secret",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Verify(tt.token, tt.secret)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Verify() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Verify() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/lorem/lorem.go
+++ b/internal/lorem/lorem.go
@@ -1,0 +1,76 @@
+package lorem
+
+import "strings"
+
+var bank = []string{
+	"lorem", "ipsum", "dolor", "sit", "amet", "consectetur",
+	"adipiscing", "elit", "sed", "do", "eiusmod", "tempor",
+	"incididunt", "ut", "labore", "et", "dolore", "magna",
+	"aliqua", "enim", "ad", "minim", "veniam", "quis",
+	"nostrud", "exercitation", "ullamco", "laboris",
+}
+
+// Words returns n space-joined words, cycling the word bank deterministically.
+func Words(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	words := make([]string, n)
+	for i := 0; i < n; i++ {
+		words[i] = bank[i%len(bank)]
+	}
+	return strings.Join(words, " ")
+}
+
+// capitalize upper-cases the first letter of a word.
+func capitalize(w string) string {
+	if w == "" {
+		return ""
+	}
+	return strings.ToUpper(w[:1]) + w[1:]
+}
+
+// sentence builds a single capitalized sentence of 6-12 words, deterministically
+// based on the provided index.
+func sentence(idx int) string {
+	count := 6 + (idx % 7) // 6..12
+	words := make([]string, count)
+	for i := 0; i < count; i++ {
+		words[i] = bank[(idx+i)%len(bank)]
+	}
+	words[0] = capitalize(words[0])
+	return strings.Join(words, " ") + "."
+}
+
+// Sentences returns n sentences, each capitalized and ending in a period,
+// joined by spaces.
+func Sentences(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	sentences := make([]string, n)
+	for i := 0; i < n; i++ {
+		sentences[i] = sentence(i)
+	}
+	return strings.Join(sentences, " ")
+}
+
+// Paragraphs returns n paragraphs, each made of 3-5 sentences, separated by
+// blank lines.
+func Paragraphs(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	paragraphs := make([]string, n)
+	idx := 0
+	for p := 0; p < n; p++ {
+		count := 3 + (p % 3) // 3..5
+		sentences := make([]string, count)
+		for i := 0; i < count; i++ {
+			sentences[i] = sentence(idx)
+			idx++
+		}
+		paragraphs[p] = strings.Join(sentences, " ")
+	}
+	return strings.Join(paragraphs, "\n\n")
+}

--- a/internal/lorem/lorem_test.go
+++ b/internal/lorem/lorem_test.go
@@ -1,0 +1,97 @@
+package lorem
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWords(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+		want int
+	}{
+		{"five", 5, 5},
+		{"zero", 0, 0},
+		{"negative", -3, 0},
+		{"cycle", len(bank) + 3, len(bank) + 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Words(tt.n)
+			if tt.want == 0 {
+				if got != "" {
+					t.Errorf("Words(%d) = %q, want empty", tt.n, got)
+				}
+				return
+			}
+			if c := len(strings.Fields(got)); c != tt.want {
+				t.Errorf("Words(%d) has %d words, want %d", tt.n, c, tt.want)
+			}
+		})
+	}
+}
+
+func TestSentences(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+	}{
+		{"two", 2},
+		{"five", 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Sentences(tt.n)
+			if c := strings.Count(got, "."); c != tt.n {
+				t.Errorf("Sentences(%d) has %d periods, want %d", tt.n, c, tt.n)
+			}
+			if got != "" && got[0] < 'A' || got != "" && got[0] > 'Z' {
+				t.Errorf("Sentences(%d) does not start capitalized: %q", tt.n, got)
+			}
+		})
+	}
+}
+
+func TestSentencesEmpty(t *testing.T) {
+	if got := Sentences(0); got != "" {
+		t.Errorf("Sentences(0) = %q, want empty", got)
+	}
+}
+
+func TestParagraphs(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+	}{
+		{"one", 1},
+		{"three", 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Paragraphs(tt.n)
+			blocks := strings.Split(got, "\n\n")
+			if len(blocks) != tt.n {
+				t.Errorf("Paragraphs(%d) produced %d blocks, want %d", tt.n, len(blocks), tt.n)
+			}
+			for _, b := range blocks {
+				c := strings.Count(b, ".")
+				if c < 3 || c > 5 {
+					t.Errorf("paragraph has %d sentences, want 3-5: %q", c, b)
+				}
+			}
+		})
+	}
+}
+
+func TestParagraphsEmpty(t *testing.T) {
+	if got := Paragraphs(0); got != "" {
+		t.Errorf("Paragraphs(0) = %q, want empty", got)
+	}
+}
+
+func TestDeterministic(t *testing.T) {
+	if Paragraphs(2) != Paragraphs(2) {
+		t.Error("Paragraphs is not deterministic")
+	}
+}

--- a/internal/regex/regex.go
+++ b/internal/regex/regex.go
@@ -1,0 +1,40 @@
+package regex
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Match compiles pattern and finds all matches (with capture groups) in value.
+// Returns "no match" if nothing matches; errors on an invalid pattern.
+func Match(pattern, value string) (string, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", err
+	}
+
+	matches := re.FindAllStringSubmatch(value, -1)
+	if len(matches) == 0 {
+		return "no match", nil
+	}
+
+	var sb strings.Builder
+	for i, m := range matches {
+		sb.WriteString(fmt.Sprintf("match %d: %q\n", i+1, m[0]))
+		for g := 1; g < len(m); g++ {
+			sb.WriteString(fmt.Sprintf("  group %d: %q\n", g, m[g]))
+		}
+	}
+
+	return strings.TrimRight(sb.String(), "\n"), nil
+}
+
+// Replace compiles pattern and replaces all matches in value with repl.
+func Replace(pattern, value, repl string) (string, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", err
+	}
+	return re.ReplaceAllString(value, repl), nil
+}

--- a/internal/regex/regex_test.go
+++ b/internal/regex/regex_test.go
@@ -1,0 +1,99 @@
+package regex
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		value    string
+		wantErr  bool
+		contains []string
+	}{
+		{
+			name:     "groups",
+			pattern:  `(\w+)@(\w+)`,
+			value:    "user@host",
+			contains: []string{"user@host", "user", "host"},
+		},
+		{
+			name:     "no match",
+			pattern:  `xyz`,
+			value:    "abc",
+			contains: []string{"no match"},
+		},
+		{
+			name:    "invalid pattern",
+			pattern: `(`,
+			value:   "abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := Match(tt.pattern, tt.value)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, c := range tt.contains {
+				if !strings.Contains(res, c) {
+					t.Fatalf("expected %q in output:\n%s", c, res)
+				}
+			}
+		})
+	}
+}
+
+func TestReplace(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		value   string
+		repl    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "simple",
+			pattern: `a`,
+			value:   "banana",
+			repl:    "o",
+			want:    "bonono",
+		},
+		{
+			name:    "invalid",
+			pattern: `(`,
+			value:   "x",
+			repl:    "y",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := Replace(tt.pattern, tt.value, tt.repl)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res != tt.want {
+				t.Fatalf("got %q, want %q", res, tt.want)
+			}
+		})
+	}
+}

--- a/internal/slug/slug.go
+++ b/internal/slug/slug.go
@@ -1,0 +1,24 @@
+package slug
+
+import "strings"
+
+// Make converts the input into a URL-friendly slug: lowercase, with any run of
+// non-alphanumeric characters collapsed into a single "-", trimmed of leading
+// and trailing hyphens.
+func Make(in string) string {
+	in = strings.ToLower(in)
+
+	var b strings.Builder
+	prevDash := false
+	for _, r := range in {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			prevDash = false
+		} else if !prevDash {
+			b.WriteByte('-')
+			prevDash = true
+		}
+	}
+
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/slug/slug_test.go
+++ b/internal/slug/slug_test.go
@@ -1,0 +1,26 @@
+package slug
+
+import "testing"
+
+func TestMake(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"simple", "Hello World", "hello-world"},
+		{"punctuation", "Hello, World!", "hello-world"},
+		{"leading trailing", "  --Hello--  ", "hello"},
+		{"multiple separators", "a   b___c", "a-b-c"},
+		{"alphanumeric", "Go 1.26 Release", "go-1-26-release"},
+		{"empty", "", ""},
+		{"only symbols", "!!!", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Make(tt.in); got != tt.want {
+				t.Errorf("Make(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sqlfmt/sqlfmt.go
+++ b/internal/sqlfmt/sqlfmt.go
@@ -1,0 +1,56 @@
+package sqlfmt
+
+import (
+	"regexp"
+	"strings"
+)
+
+var wsRe = regexp.MustCompile(`\s+`)
+
+// keywords to uppercase when they appear as whole words.
+var keywords = []string{
+	"SELECT", "FROM", "WHERE", "AND", "OR", "JOIN", "LEFT", "RIGHT",
+	"INNER", "OUTER", "ON", "GROUP BY", "ORDER BY", "HAVING", "LIMIT",
+	"INSERT", "INTO", "VALUES", "UPDATE", "SET", "DELETE",
+}
+
+// major clause keywords that get a newline before them.
+var clauses = []string{
+	"LEFT JOIN", "RIGHT JOIN", "INNER JOIN",
+	"SELECT", "FROM", "WHERE", "GROUP BY", "ORDER BY", "HAVING", "LIMIT", "JOIN",
+}
+
+// Format is a lightweight SQL formatter: it uppercases known keywords and
+// places newlines before major clause keywords.
+func Format(in string) (string, error) {
+	s := strings.TrimSpace(wsRe.ReplaceAllString(in, " "))
+
+	for _, kw := range keywords {
+		re := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(kw) + `\b`)
+		s = re.ReplaceAllString(s, kw)
+	}
+
+	for _, cl := range clauses {
+		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(cl) + `\b`)
+		s = re.ReplaceAllString(s, "\n"+cl)
+	}
+
+	s = strings.TrimSpace(s)
+	// normalize lines: trim trailing spaces and drop a leading blank line.
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		l = strings.TrimSpace(l)
+		if l == "" {
+			continue
+		}
+		out = append(out, l)
+	}
+
+	return strings.Join(out, "\n"), nil
+}
+
+// Minify collapses all whitespace (including newlines) to single spaces.
+func Minify(in string) (string, error) {
+	return strings.TrimSpace(wsRe.ReplaceAllString(in, " ")), nil
+}

--- a/internal/sqlfmt/sqlfmt_test.go
+++ b/internal/sqlfmt/sqlfmt_test.go
@@ -1,0 +1,43 @@
+package sqlfmt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormat(t *testing.T) {
+	res, err := Format("select a from t where x=1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res, "SELECT") {
+		t.Fatalf("expected SELECT in output:\n%s", res)
+	}
+	if !strings.Contains(res, "\nFROM") {
+		t.Fatalf("expected newline before FROM in output:\n%s", res)
+	}
+}
+
+func TestMinify(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"newlines", "select\n  a\nfrom t", "select a from t"},
+		{"spaces", "a    b   c", "a b c"},
+		{"trim", "  x  ", "x"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := Minify(tt.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if res != tt.want {
+				t.Fatalf("got %q, want %q", res, tt.want)
+			}
+		})
+	}
+}

--- a/internal/text/text.go
+++ b/internal/text/text.go
@@ -1,0 +1,29 @@
+package text
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Count returns a multi-line report about the given input string.
+func Count(in string) string {
+	chars := utf8.RuneCountInString(in)
+	bytes := len(in)
+	words := len(strings.Fields(in))
+
+	lines := strings.Count(in, "\n")
+	if in != "" && !strings.HasSuffix(in, "\n") {
+		lines++
+	}
+
+	readingTime := (words + 199) / 200
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Characters:   %d\n", chars)
+	fmt.Fprintf(&b, "Bytes:        %d\n", bytes)
+	fmt.Fprintf(&b, "Words:        %d\n", words)
+	fmt.Fprintf(&b, "Lines:        %d\n", lines)
+	fmt.Fprintf(&b, "Reading time: %d min", readingTime)
+	return b.String()
+}

--- a/internal/text/text_test.go
+++ b/internal/text/text_test.go
@@ -1,0 +1,40 @@
+package text
+
+import "testing"
+
+func TestCount(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: "Characters:   0\nBytes:        0\nWords:        0\nLines:        0\nReading time: 0 min",
+		},
+		{
+			name: "single line no newline",
+			in:   "hello world",
+			want: "Characters:   11\nBytes:        11\nWords:        2\nLines:        1\nReading time: 1 min",
+		},
+		{
+			name: "two lines trailing newline",
+			in:   "a b\nc d\n",
+			want: "Characters:   8\nBytes:        8\nWords:        4\nLines:        2\nReading time: 1 min",
+		},
+		{
+			name: "multibyte",
+			in:   "héllo",
+			want: "Characters:   5\nBytes:        6\nWords:        1\nLines:        1\nReading time: 1 min",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Count(tt.in); got != tt.want {
+				t.Errorf("Count(%q) =\n%q\nwant\n%q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/textcase/textcase.go
+++ b/internal/textcase/textcase.go
@@ -1,0 +1,106 @@
+package textcase
+
+import (
+	"strings"
+	"unicode"
+)
+
+// tokenize splits the input into lowercase words, breaking on spaces,
+// underscores, hyphens and camelCase boundaries.
+func tokenize(in string) []string {
+	var words []string
+	var current []rune
+
+	flush := func() {
+		if len(current) > 0 {
+			words = append(words, strings.ToLower(string(current)))
+			current = current[:0]
+		}
+	}
+
+	runes := []rune(in)
+	for i, r := range runes {
+		switch {
+		case r == ' ' || r == '_' || r == '-':
+			flush()
+		case unicode.IsUpper(r):
+			// camelCase boundary: previous rune is lower/digit, or next rune is lower
+			if i > 0 {
+				prev := runes[i-1]
+				if unicode.IsLower(prev) || unicode.IsDigit(prev) {
+					flush()
+				} else if unicode.IsUpper(prev) && i+1 < len(runes) && unicode.IsLower(runes[i+1]) {
+					flush()
+				}
+			}
+			current = append(current, r)
+		default:
+			current = append(current, r)
+		}
+	}
+	flush()
+	return words
+}
+
+func capitalize(w string) string {
+	if w == "" {
+		return ""
+	}
+	r := []rune(w)
+	r[0] = unicode.ToUpper(r[0])
+	return string(r)
+}
+
+// ToCamel converts the input to camelCase.
+func ToCamel(in string) string {
+	words := tokenize(in)
+	var b strings.Builder
+	for i, w := range words {
+		if i == 0 {
+			b.WriteString(w)
+		} else {
+			b.WriteString(capitalize(w))
+		}
+	}
+	return b.String()
+}
+
+// ToPascal converts the input to PascalCase.
+func ToPascal(in string) string {
+	words := tokenize(in)
+	var b strings.Builder
+	for _, w := range words {
+		b.WriteString(capitalize(w))
+	}
+	return b.String()
+}
+
+// ToSnake converts the input to snake_case.
+func ToSnake(in string) string {
+	return strings.Join(tokenize(in), "_")
+}
+
+// ToKebab converts the input to kebab-case.
+func ToKebab(in string) string {
+	return strings.Join(tokenize(in), "-")
+}
+
+// ToTitle converts the input to Title Case.
+func ToTitle(in string) string {
+	words := tokenize(in)
+	out := make([]string, len(words))
+	for i, w := range words {
+		out[i] = capitalize(w)
+	}
+	return strings.Join(out, " ")
+}
+
+// ToUpper upper-cases the entire input.
+func ToUpper(in string) string {
+	return strings.ToUpper(in)
+}
+
+// ToLower lower-cases the entire input.
+func ToLower(in string) string {
+	return strings.ToLower(in)
+}

--- a/internal/textcase/textcase_test.go
+++ b/internal/textcase/textcase_test.go
@@ -1,0 +1,52 @@
+package textcase
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTokenize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"camel", "HelloWorld", []string{"hello", "world"}},
+		{"snake", "hello_world", []string{"hello", "world"}},
+		{"kebab", "hello-world", []string{"hello", "world"}},
+		{"space", "hello world", []string{"hello", "world"}},
+		{"acronym", "HTTPServer", []string{"http", "server"}},
+		{"empty", "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tokenize(tt.in); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("tokenize(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConversions(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(string) string
+		in   string
+		want string
+	}{
+		{"camel", ToCamel, "hello_world foo", "helloWorldFoo"},
+		{"pascal", ToPascal, "hello-world", "HelloWorld"},
+		{"snake", ToSnake, "HelloWorld", "hello_world"},
+		{"kebab", ToKebab, "Hello World", "hello-world"},
+		{"title", ToTitle, "hello_world", "Hello World"},
+		{"upper", ToUpper, "Hello World", "HELLO WORLD"},
+		{"lower", ToLower, "Hello World", "hello world"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fn(tt.in); got != tt.want {
+				t.Errorf("%s(%q) = %q, want %q", tt.name, tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/timeconv/timeconv.go
+++ b/internal/timeconv/timeconv.go
@@ -1,0 +1,42 @@
+package timeconv
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// Now returns the current time in several formats.
+func Now() (string, error) {
+	t := time.Now()
+	return fmt.Sprintf("Unix: %d\nUnixMilli: %d\nISO: %s\nUTC: %s",
+		t.Unix(),
+		t.UnixMilli(),
+		t.Format(time.RFC3339),
+		t.UTC().Format(time.RFC3339),
+	), nil
+}
+
+// ToUnix parses a date string and returns its unix seconds as a string.
+func ToUnix(in string) (string, error) {
+	layouts := []string{
+		time.RFC3339,
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, in); err == nil {
+			return strconv.FormatInt(t.Unix(), 10), nil
+		}
+	}
+	return "", fmt.Errorf("could not parse date: %q", in)
+}
+
+// FromUnix parses unix seconds and returns an RFC3339 UTC string.
+func FromUnix(in string) (string, error) {
+	n, err := strconv.ParseInt(in, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid unix seconds: %q", in)
+	}
+	return time.Unix(n, 0).UTC().Format(time.RFC3339), nil
+}

--- a/internal/timeconv/timeconv_test.go
+++ b/internal/timeconv/timeconv_test.go
@@ -1,0 +1,71 @@
+package timeconv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNow(t *testing.T) {
+	got, err := Now()
+	if err != nil {
+		t.Fatalf("Now() err=%v", err)
+	}
+	if got == "" {
+		t.Errorf("Now() returned empty string")
+	}
+}
+
+func TestFromUnix(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         string
+		wantPrefix string
+		wantErr    bool
+	}{
+		{"epoch", "0", "1970-01-01", false},
+		{"non numeric", "abc", "", true},
+		{"empty", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FromUnix(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("FromUnix(%q) err=%v wantErr=%v", tt.in, err, tt.wantErr)
+			}
+			if !tt.wantErr && !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("FromUnix(%q)=%q want prefix %q", tt.in, got, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestToUnixRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr bool
+	}{
+		{"date", "1970-01-01", false},
+		{"datetime", "2000-01-02 03:04:05", false},
+		{"invalid", "not-a-date", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unix, err := ToUnix(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ToUnix(%q) err=%v wantErr=%v", tt.in, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			back, err := FromUnix(unix)
+			if err != nil {
+				t.Fatalf("FromUnix(%q) err=%v", unix, err)
+			}
+			datePart := strings.SplitN(tt.in, " ", 2)[0]
+			if !strings.HasPrefix(back, datePart) {
+				t.Errorf("round trip of %q got %q want prefix %q", tt.in, back, datePart)
+			}
+		})
+	}
+}

--- a/internal/toml/toml.go
+++ b/internal/toml/toml.go
@@ -1,0 +1,48 @@
+package toml
+
+import (
+	"bytes"
+	"encoding/json"
+
+	btoml "github.com/BurntSushi/toml"
+	"gopkg.in/yaml.v3"
+)
+
+// ToJSON decodes a TOML document and re-encodes it as indented JSON.
+func ToJSON(in string) (string, error) {
+	var m map[string]interface{}
+	if _, err := btoml.Decode(in, &m); err != nil {
+		return "", err
+	}
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// ToYAML decodes a TOML document and re-encodes it as YAML.
+func ToYAML(in string) (string, error) {
+	var m map[string]interface{}
+	if _, err := btoml.Decode(in, &m); err != nil {
+		return "", err
+	}
+	b, err := yaml.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// FromJSON parses a JSON document and re-encodes it as TOML.
+func FromJSON(in string) (string, error) {
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(in), &m); err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := btoml.NewEncoder(&buf).Encode(m); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/internal/toml/toml_test.go
+++ b/internal/toml/toml_test.go
@@ -1,0 +1,60 @@
+package toml
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestToJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"simple", "a = 1", `"a": 1`, false},
+		{"invalid", "a = =", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ToJSON(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ToJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("ToJSON() = %q, want contains %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	in := `{"a":1,"b":"two"}`
+	tomlOut, err := FromJSON(in)
+	if err != nil {
+		t.Fatalf("FromJSON() error = %v", err)
+	}
+	jsonOut, err := ToJSON(tomlOut)
+	if err != nil {
+		t.Fatalf("ToJSON() error = %v", err)
+	}
+	if !strings.Contains(jsonOut, `"a": 1`) {
+		t.Errorf("round trip = %q, want contains %q", jsonOut, `"a": 1`)
+	}
+	if !strings.Contains(jsonOut, `"b": "two"`) {
+		t.Errorf("round trip = %q, want contains %q", jsonOut, `"b": "two"`)
+	}
+}
+
+func TestToYAML(t *testing.T) {
+	got, err := ToYAML("a = 1")
+	if err != nil {
+		t.Fatalf("ToYAML() error = %v", err)
+	}
+	if !strings.Contains(got, "a: 1") {
+		t.Errorf("ToYAML() = %q, want contains %q", got, "a: 1")
+	}
+}

--- a/internal/uuid/uuid.go
+++ b/internal/uuid/uuid.go
@@ -1,0 +1,54 @@
+package uuid
+
+import (
+	"crypto/rand"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+var uuidRe = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+func format(b []byte) string {
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// V4 returns a random UUID version 4.
+func V4() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return format(b[:]), nil
+}
+
+// V7 returns a time-ordered UUID version 7.
+func V7() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+
+	ms := time.Now().UnixMilli()
+	b[0] = byte(ms >> 40)
+	b[1] = byte(ms >> 32)
+	b[2] = byte(ms >> 24)
+	b[3] = byte(ms >> 16)
+	b[4] = byte(ms >> 8)
+	b[5] = byte(ms)
+
+	b[6] = (b[6] & 0x0f) | 0x70
+	b[8] = (b[8] & 0x3f) | 0x80
+	return format(b[:]), nil
+}
+
+// Validate returns "valid" if in is a canonical UUID, otherwise "invalid".
+func Validate(in string) (string, error) {
+	if uuidRe.MatchString(in) {
+		return "valid", nil
+	}
+	return "invalid", nil
+}

--- a/internal/uuid/uuid_test.go
+++ b/internal/uuid/uuid_test.go
@@ -1,0 +1,39 @@
+package uuid
+
+import "testing"
+
+func TestGenerateAndValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		gen  func() (string, error)
+	}{
+		{name: "v4", gen: V4},
+		{name: "v7", gen: V7},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := tt.gen()
+			if err != nil {
+				t.Fatalf("generation error: %v", err)
+			}
+			res, err := Validate(id)
+			if err != nil {
+				t.Fatalf("Validate error: %v", err)
+			}
+			if res != "valid" {
+				t.Fatalf("generated id %q reported %q, want valid", id, res)
+			}
+		})
+	}
+}
+
+func TestValidateInvalid(t *testing.T) {
+	res, err := Validate("not-a-uuid")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != "invalid" {
+		t.Fatalf("got %q, want invalid", res)
+	}
+}


### PR DESCRIPTION
Adds 22 new offline utilities, each as an `internal/<domain>` + `cmd/<domain>` package following the existing pattern, with unit tests.

| Command | Actions |
|---------|---------|
| `jwt` | decode, verify (HS256) |
| `hash` | md5, sha1, sha256, sha512, crc32 |
| `hex` | encode, decode |
| `gzip` | compress, decompress (base64-wrapped) |
| `bcrypt` | hash, verify |
| `base58` | encode, decode |
| `uuid` | gen (v4/v7), validate |
| `cert` | info (x509/PEM) |
| `text` | count (chars/words/lines/reading time) |
| `case` | camel, pascal, snake, kebab, title, upper, lower |
| `slug` | make |
| `lorem` | words, sentences, paragraphs |
| `diff` | line diff (LCS) |
| `regex` | match, replace |
| `html` | escape, unescape, strip |
| `sql` | format, minify |
| `toml` | toJSON, toYAML, fromJSON |
| `jq` | query (JSON path) |
| `ip` | cidr, toInt, fromInt |
| `cron` | explain, next |
| `color` | toRGB, toHex, toHSL |
| `time` | now, toUnix, fromUnix |

## Notes
- New deps: `golang.org/x/crypto` (bcrypt) and `github.com/BurntSushi/toml`. Everything else is standard library only (base58, diff, cron, jq, color, etc. are hand-rolled).
- All conversions keep the privacy-first, offline ethos of the tool.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./...` — every new internal package has table-driven tests; all pass.
- `goreleaser build --snapshot` succeeds.
- Every command smoke-tested on the built binary.

Examples:
```
$ swiss diff --a $'x\ny\nz' --b $'x\nY\nz'
  x
- y
+ Y
  z

$ swiss ip cidr --value 192.168.1.0/24
Network address: 192.168.1.0
...
Broadcast: 192.168.1.255

$ swiss jwt decode --value <token>
Header: { "alg": "HS256", ... }
Payload: { ... }
Expires: 2033-05-18T...
```

README checklist updated to include all new tools.