### PR TITLE
Docs site: fix hero logo/wordmark alignment

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -103,10 +103,10 @@
     padding:6px 13px;border-radius:999px;margin-bottom:24px;
   }
   .hero .badge .dot{width:7px;height:7px;border-radius:50%;background:var(--green);box-shadow:0 0 8px var(--green)}
-  .wordmark{display:flex;align-items:center;justify-content:center;gap:18px;margin:0 0 14px}
-  .wordmark .logo{--s:56px}
+  .wordmark{display:flex;align-items:center;justify-content:center;gap:.24em;margin:0 0 14px;font-size:clamp(52px,11vw,96px)}
+  .wordmark .logo{--s:.66em;border-radius:.17em;transform:translateY(.045em)}
   .wordmark h1{
-    margin:0;font-size:clamp(52px,11vw,96px);font-weight:800;letter-spacing:-3px;line-height:1;
+    margin:0;font-size:1em;font-weight:800;letter-spacing:-.032em;line-height:1;
     background:linear-gradient(180deg,#fff,#c9d2dc);
     -webkit-background-clip:text;background-clip:text;color:transparent;
   }


### PR DESCRIPTION
The hero logo was a fixed 56px while the wordmark scales responsively, leaving them vertically misaligned. Now the logo scales with the wordmark's em and is nudged to the text's optical center, so they stay aligned at every size.