### PR TITLE
Generalize stdin (-) + -v shorthand to all commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ More installation options will come
 text, networking and more — all running 100% locally.
 
 👉 **Browse the full command reference with live examples at [huseyinbabal.github.io/swiss](https://huseyinbabal.github.io/swiss/)**, or run `swiss --help`.
+
+### Pipes & stdin
+
+Any command's value flag accepts `-` to read from stdin, so commands compose:
+
+```bash
+cat data.json | swiss json toYAML --value -
+echo "hello" | swiss base64 encode -v - | swiss base64 decode -v -
+```

--- a/cmd/base58.go
+++ b/cmd/base58.go
@@ -41,7 +41,7 @@ var base58DecodeCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{base58EncodeCmd, base58DecodeCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&base58Value, "value", "", "input")
+		c.Flags().StringVarP(&base58Value, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/base64.go
+++ b/cmd/base64.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
-	"io"
 	"log"
 	"swiss/internal/base64"
+
+	"github.com/spf13/cobra"
 )
 
 var b64Value string
@@ -18,14 +18,6 @@ var base64EncodeCmd = &cobra.Command{
 	Use:   "encode",
 	Short: "Encodes given string with base64",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if b64Value == "-" {
-			inputReader := cmd.InOrStdin()
-			b, err := io.ReadAll(inputReader)
-			if err != nil {
-				return err
-			}
-			b64Value = string(b)
-		}
 		fmt.Print(base64.Encode(b64Value))
 		return nil
 	},
@@ -35,14 +27,6 @@ var base64DecodeCmd = &cobra.Command{
 	Use:   "decode",
 	Short: "Decodes given base64 string",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if b64Value == "-" {
-			inputReader := cmd.InOrStdin()
-			b, err := io.ReadAll(inputReader)
-			if err != nil {
-				return err
-			}
-			b64Value = string(b)
-		}
 		res, err := base64.Decode(b64Value)
 		if err != nil {
 			return err

--- a/cmd/bcrypt.go
+++ b/cmd/bcrypt.go
@@ -40,12 +40,12 @@ var bcryptVerifyCmd = &cobra.Command{
 }
 
 func init() {
-	bcryptHashCmd.Flags().StringVar(&bcryptValue, "value", "", "password to hash")
+	bcryptHashCmd.Flags().StringVarP(&bcryptValue, "value", "v", "", "password to hash")
 	if err := bcryptHashCmd.MarkFlagRequired("value"); err != nil {
 		log.Fatalf("Please provide --value")
 	}
 
-	bcryptVerifyCmd.Flags().StringVar(&bcryptValue, "value", "", "bcrypt hash")
+	bcryptVerifyCmd.Flags().StringVarP(&bcryptValue, "value", "v", "", "bcrypt hash")
 	bcryptVerifyCmd.Flags().StringVar(&bcryptPassword, "password", "", "password to verify")
 	if err := bcryptVerifyCmd.MarkFlagRequired("value"); err != nil {
 		log.Fatalf("Please provide --value")

--- a/cmd/case.go
+++ b/cmd/case.go
@@ -86,7 +86,7 @@ func init() {
 		caseLowerCmd,
 	}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&caseValue, "value", "", "input")
+		c.Flags().StringVarP(&caseValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/cert.go
+++ b/cmd/cert.go
@@ -28,7 +28,7 @@ var certInfoCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{certInfoCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&certValue, "value", "", "PEM encoded certificate")
+		c.Flags().StringVarP(&certValue, "value", "v", "", "PEM encoded certificate")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/color.go
+++ b/cmd/color.go
@@ -54,7 +54,7 @@ var colorToHSLCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{colorToRGBCmd, colorToHexCmd, colorToHSLCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&colorValue, "value", "", "input")
+		c.Flags().StringVarP(&colorValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -39,13 +39,13 @@ var cronNextCmd = &cobra.Command{
 }
 
 func init() {
-	cronExplainCmd.Flags().StringVar(&cronValue, "value", "", "input")
+	cronExplainCmd.Flags().StringVarP(&cronValue, "value", "v", "", "input")
 	if err := cronExplainCmd.MarkFlagRequired("value"); err != nil {
 		panic("Please provide --value")
 	}
 	cronCmd.AddCommand(cronExplainCmd)
 
-	cronNextCmd.Flags().StringVar(&cronValue, "value", "", "input")
+	cronNextCmd.Flags().StringVarP(&cronValue, "value", "v", "", "input")
 	cronNextCmd.Flags().IntVar(&cronCount, "count", 5, "number of times to show")
 	if err := cronNextCmd.MarkFlagRequired("value"); err != nil {
 		panic("Please provide --value")

--- a/cmd/csv.go
+++ b/cmd/csv.go
@@ -88,7 +88,7 @@ func init() {
 		csvUnescapeCmd,
 	}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&csvValue, "value", "", "CSV string")
+		c.Flags().StringVarP(&csvValue, "value", "v", "", "CSV string")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide a valid csv with --value parameter")
 		}

--- a/cmd/gzip.go
+++ b/cmd/gzip.go
@@ -41,7 +41,7 @@ var gzipDecompressCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{gzipCompressCmd, gzipDecompressCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&gzipValue, "value", "", "input")
+		c.Flags().StringVarP(&gzipValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/hash.go
+++ b/cmd/hash.go
@@ -60,7 +60,7 @@ var hashCRC32Cmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{hashMD5Cmd, hashSHA1Cmd, hashSHA256Cmd, hashSHA512Cmd, hashCRC32Cmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&hashValue, "value", "", "input")
+		c.Flags().StringVarP(&hashValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/hex.go
+++ b/cmd/hex.go
@@ -41,7 +41,7 @@ var hexDecodeCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{hexEncodeCmd, hexDecodeCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&hexValue, "value", "", "input")
+		c.Flags().StringVarP(&hexValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/html.go
+++ b/cmd/html.go
@@ -54,7 +54,7 @@ var htmlStripCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{htmlEscapeCmd, htmlUnescapeCmd, htmlStripCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&htmlValue, "value", "", "input")
+		c.Flags().StringVarP(&htmlValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/ip.go
+++ b/cmd/ip.go
@@ -53,7 +53,7 @@ var ipFromIntCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{ipCidrCmd, ipToIntCmd, ipFromIntCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&ipValue, "value", "", "input")
+		c.Flags().StringVarP(&ipValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			panic("Please provide --value")
 		}

--- a/cmd/jq.go
+++ b/cmd/jq.go
@@ -25,7 +25,7 @@ var jqCmd = &cobra.Command{
 
 func init() {
 	jqCmd.Flags().StringVar(&jqPath, "path", "", "path")
-	jqCmd.Flags().StringVar(&jqValue, "value", "", "input")
+	jqCmd.Flags().StringVarP(&jqValue, "value", "v", "", "input")
 	if err := jqCmd.MarkFlagRequired("path"); err != nil {
 		panic("Please provide --path")
 	}

--- a/cmd/json.go
+++ b/cmd/json.go
@@ -140,7 +140,7 @@ func init() {
 		jsonUnescapeCmd,
 	}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&jsonValue, "value", "", "JSON string")
+		c.Flags().StringVarP(&jsonValue, "value", "v", "", "JSON string")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide a valid json with --value parameter")
 		}

--- a/cmd/jwt.go
+++ b/cmd/jwt.go
@@ -42,7 +42,7 @@ var jwtVerifyCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{jwtDecodeCmd, jwtVerifyCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&jwtValue, "value", "", "input")
+		c.Flags().StringVarP(&jwtValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/regex.go
+++ b/cmd/regex.go
@@ -45,7 +45,7 @@ func init() {
 	if err := regexMatchCmd.MarkFlagRequired("pattern"); err != nil {
 		log.Fatalf("Please provide --pattern")
 	}
-	regexMatchCmd.Flags().StringVar(&regexValue, "value", "", "input")
+	regexMatchCmd.Flags().StringVarP(&regexValue, "value", "v", "", "input")
 	if err := regexMatchCmd.MarkFlagRequired("value"); err != nil {
 		log.Fatalf("Please provide --value")
 	}
@@ -54,7 +54,7 @@ func init() {
 	if err := regexReplaceCmd.MarkFlagRequired("pattern"); err != nil {
 		log.Fatalf("Please provide --pattern")
 	}
-	regexReplaceCmd.Flags().StringVar(&regexValue, "value", "", "input")
+	regexReplaceCmd.Flags().StringVarP(&regexValue, "value", "v", "", "input")
 	if err := regexReplaceCmd.MarkFlagRequired("value"); err != nil {
 		log.Fatalf("Please provide --value")
 	}

--- a/cmd/rss.go
+++ b/cmd/rss.go
@@ -29,7 +29,7 @@ var rssToJsonCmd = &cobra.Command{
 }
 
 func init() {
-	rssToJsonCmd.Flags().StringVar(&rssValue, "value", "", "RSS string")
+	rssToJsonCmd.Flags().StringVarP(&rssValue, "value", "v", "", "RSS string")
 	if err := rssToJsonCmd.MarkFlagRequired("value"); err != nil {
 		log.Fatalf("Please provide a valid rss with --value parameter")
 	}

--- a/cmd/slug.go
+++ b/cmd/slug.go
@@ -20,7 +20,7 @@ var slugCmd = &cobra.Command{
 }
 
 func init() {
-	slugCmd.Flags().StringVar(&slugValue, "value", "", "input")
+	slugCmd.Flags().StringVarP(&slugValue, "value", "v", "", "input")
 	if err := slugCmd.MarkFlagRequired("value"); err != nil {
 		log.Fatalf("Please provide --value")
 	}

--- a/cmd/sql.go
+++ b/cmd/sql.go
@@ -42,7 +42,7 @@ var sqlMinifyCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{sqlFormatCmd, sqlMinifyCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&sqlValue, "value", "", "input")
+		c.Flags().StringVarP(&sqlValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/stdin.go
+++ b/cmd/stdin.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// stdinFlags are the value-bearing flags whose literal "-" means
+// "read this value from stdin", enabling pipes such as:
+//
+//	echo "hello" | swiss base64 encode -v - | swiss base64 decode -v -
+//	cat data.json | swiss json toYAML --value -
+var stdinFlags = []string{"value", "url"}
+
+// resolveStdin replaces any value flag set to "-" with the full contents of the
+// command's stdin. It runs before every command via rootCmd.PersistentPreRunE.
+func resolveStdin(cmd *cobra.Command) error {
+	for _, name := range stdinFlags {
+		f := cmd.Flags().Lookup(name)
+		if f == nil || f.Value.String() != "-" {
+			continue
+		}
+		b, err := io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return fmt.Errorf("failed to read stdin: %w", err)
+		}
+		if err := cmd.Flags().Set(name, string(b)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		return resolveStdin(cmd)
+	}
+}

--- a/cmd/stdin_test.go
+++ b/cmd/stdin_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestResolveStdinReadsValueFlag(t *testing.T) {
+	c := &cobra.Command{}
+	var v string
+	c.Flags().StringVar(&v, "value", "", "")
+	if err := c.Flags().Set("value", "-"); err != nil {
+		t.Fatal(err)
+	}
+	c.SetIn(strings.NewReader("piped content"))
+
+	if err := resolveStdin(c); err != nil {
+		t.Fatalf("resolveStdin: %v", err)
+	}
+	if v != "piped content" {
+		t.Errorf("value = %q, want %q", v, "piped content")
+	}
+}
+
+func TestResolveStdinReadsUrlFlag(t *testing.T) {
+	c := &cobra.Command{}
+	var u string
+	c.Flags().StringVar(&u, "url", "", "")
+	_ = c.Flags().Set("url", "-")
+	c.SetIn(strings.NewReader("a b&c"))
+
+	if err := resolveStdin(c); err != nil {
+		t.Fatal(err)
+	}
+	if u != "a b&c" {
+		t.Errorf("url = %q, want %q", u, "a b&c")
+	}
+}
+
+func TestResolveStdinLeavesLiteralValue(t *testing.T) {
+	c := &cobra.Command{}
+	var v string
+	c.Flags().StringVar(&v, "value", "", "")
+	_ = c.Flags().Set("value", "hello")
+	c.SetIn(strings.NewReader("should be ignored"))
+
+	if err := resolveStdin(c); err != nil {
+		t.Fatal(err)
+	}
+	if v != "hello" {
+		t.Errorf("value = %q, want %q (stdin must not be read)", v, "hello")
+	}
+}
+
+func TestResolveStdinNoValueFlag(t *testing.T) {
+	c := &cobra.Command{} // command without a value/url flag
+	if err := resolveStdin(c); err != nil {
+		t.Errorf("resolveStdin on flagless command: %v", err)
+	}
+}

--- a/cmd/text.go
+++ b/cmd/text.go
@@ -25,7 +25,7 @@ var textCountCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{textCountCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&textValue, "value", "", "input")
+		c.Flags().StringVarP(&textValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/time.go
+++ b/cmd/time.go
@@ -54,7 +54,7 @@ var timeFromUnixCmd = &cobra.Command{
 func init() {
 	valueCommands := []*cobra.Command{timeToUnixCmd, timeFromUnixCmd}
 	for _, c := range valueCommands {
-		c.Flags().StringVar(&timeValue, "value", "", "input")
+		c.Flags().StringVarP(&timeValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide --value")
 		}

--- a/cmd/toml.go
+++ b/cmd/toml.go
@@ -51,7 +51,7 @@ var tomlFromJSONCmd = &cobra.Command{
 func init() {
 	subCommands := []*cobra.Command{tomlToJSONCmd, tomlToYAMLCmd, tomlFromJSONCmd}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&tomlValue, "value", "", "input")
+		c.Flags().StringVarP(&tomlValue, "value", "v", "", "input")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			panic("Please provide --value")
 		}

--- a/cmd/uuid.go
+++ b/cmd/uuid.go
@@ -53,7 +53,7 @@ var uuidValidateCmd = &cobra.Command{
 func init() {
 	uuidGenCmd.Flags().IntVar(&uuidVersion, "version", 4, "uuid version (4 or 7)")
 
-	uuidValidateCmd.Flags().StringVar(&uuidValue, "value", "", "uuid to validate")
+	uuidValidateCmd.Flags().StringVarP(&uuidValue, "value", "v", "", "uuid to validate")
 	if err := uuidValidateCmd.MarkFlagRequired("value"); err != nil {
 		log.Fatalf("Please provide --value")
 	}

--- a/cmd/xml.go
+++ b/cmd/xml.go
@@ -114,7 +114,7 @@ func init() {
 		xmlUnescapeCmd,
 	}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&xmlValue, "value", "", "XML string")
+		c.Flags().StringVarP(&xmlValue, "value", "v", "", "XML string")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide a valid xml with --value parameter")
 		}

--- a/cmd/yaml.go
+++ b/cmd/yaml.go
@@ -84,7 +84,7 @@ func init() {
 		yamlToCsvCmd,
 	}
 	for _, c := range subCommands {
-		c.Flags().StringVar(&yamlValue, "value", "", "YAML string")
+		c.Flags().StringVarP(&yamlValue, "value", "v", "", "YAML string")
 		if err := c.MarkFlagRequired("value"); err != nil {
 			log.Fatalf("Please provide a valid yaml with --value parameter")
 		}

--- a/docs/index.html
+++ b/docs/index.html
@@ -120,6 +120,9 @@
   }
   .install pre{margin:0;font-family:var(--mono);font-size:14px;color:var(--text);overflow:auto;flex:1;white-space:pre}
   .install .pfx{color:var(--accent-2);user-select:none}
+  .pipetip{max-width:560px;margin:14px auto 0;font-size:13px;color:var(--muted);line-height:1.7}
+  .pipetip code{font-family:var(--mono);font-size:12px;background:var(--panel);border:1px solid var(--border-soft);
+    border-radius:6px;padding:2px 6px;color:#cdd6e0;white-space:nowrap}
   .copybtn{
     flex:none;display:inline-flex;align-items:center;gap:6px;
     border:1px solid var(--border);background:var(--panel-2);color:var(--muted);
@@ -292,6 +295,8 @@ brew install swiss" aria-label="Copy install commands">
           <span>Copy</span>
         </button>
       </div>
+      <p class="pipetip">Pipe-friendly — pass <code>-</code> to read the value from stdin:<br>
+        <code>cat data.json | swiss json toYAML --value -</code> &nbsp;·&nbsp; <code>echo hi | swiss base64 encode -v -</code></p>
     </div>
   </section>
 


### PR DESCRIPTION
Follow-up to #2 (base64 stdin by @gungoren), extending the same idea to the whole CLI.

## What
- **`cmd/stdin.go`** — a `rootCmd.PersistentPreRunE` that, before any command runs, resolves a `--value` or `--url` flag set to `-` by reading the command's stdin. So **every** value-taking command is now pipe-friendly:
  ```bash
  cat data.json | swiss json toYAML --value -
  echo hi | swiss base64 encode -v - | swiss base64 decode -v -
  printf foo | swiss hash sha256 -v -
  ```
- **`-v` shorthand for `--value` across all commands** (consistent with the `-v` #2 added to base64).
- Removed the now-redundant inline stdin handling from `base64` — the central hook covers it (keeps @gungoren's `-v` + behavior).
- **Tests** for `resolveStdin` (first tests in the `cmd` package).
- Docs site + README updated with piping examples.

## Verification
- `go build`, `go vet`, `gofmt -l` clean; `go test ./...` all pass.
- Smoke-tested piping across json/base64/hash/url/jwt and confirmed literal values still work.

Credits @gungoren for the original stdin idea in #2.