### PR TITLE
Add qr command

### DIFF
--- a/cmd/qr.go
+++ b/cmd/qr.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"swiss/internal/qr"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	qrValue  string
+	qrOutput string
+	qrSize   int
+)
+
+var qrCmd = &cobra.Command{
+	Use:   "qr",
+	Short: "Generates a QR code from a value",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if qrOutput != "" {
+			png, err := qr.PNG(qrValue, qrSize)
+			if err != nil {
+				return err
+			}
+			if err := os.WriteFile(qrOutput, png, 0o644); err != nil {
+				return err
+			}
+			fmt.Printf("QR code written to %s\n", qrOutput)
+			return nil
+		}
+		out, err := qr.Terminal(qrValue)
+		if err != nil {
+			return err
+		}
+		fmt.Print(out)
+		return nil
+	},
+}
+
+func init() {
+	qrCmd.Flags().StringVarP(&qrValue, "value", "v", "", "value to encode")
+	qrCmd.Flags().StringVarP(&qrOutput, "output", "o", "", "write a PNG to this path instead of printing to the terminal")
+	qrCmd.Flags().IntVar(&qrSize, "size", 256, "PNG size in pixels (used with --output)")
+	if err := qrCmd.MarkFlagRequired("value"); err != nil {
+		log.Fatalf("Please provide a valid value with --value parameter")
+	}
+	rootCmd.AddCommand(qrCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/alecthomas/chroma/v2 v2.27.0
 	github.com/basgys/goxml2json v1.1.0
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.53.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/internal/qr/qr.go
+++ b/internal/qr/qr.go
@@ -1,0 +1,31 @@
+package qr
+
+import (
+	"fmt"
+
+	qrcode "github.com/skip2/go-qrcode"
+)
+
+// Terminal renders content as a compact, scannable QR code using half-block
+// characters, suitable for printing directly in a terminal.
+func Terminal(content string) (string, error) {
+	if content == "" {
+		return "", fmt.Errorf("cannot encode an empty value")
+	}
+	q, err := qrcode.New(content, qrcode.Medium)
+	if err != nil {
+		return "", err
+	}
+	return q.ToSmallString(false), nil
+}
+
+// PNG returns a PNG image of the QR code for content at the given pixel size.
+func PNG(content string, size int) ([]byte, error) {
+	if content == "" {
+		return nil, fmt.Errorf("cannot encode an empty value")
+	}
+	if size <= 0 {
+		size = 256
+	}
+	return qrcode.Encode(content, qrcode.Medium, size)
+}

--- a/internal/qr/qr_test.go
+++ b/internal/qr/qr_test.go
@@ -1,0 +1,42 @@
+package qr
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestTerminal(t *testing.T) {
+	out, err := Terminal("https://github.com/huseyinbabal/swiss")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+	if !strings.ContainsAny(out, "█▀▄") {
+		t.Error("output does not look like a block QR code")
+	}
+}
+
+func TestTerminalEmpty(t *testing.T) {
+	if _, err := Terminal(""); err == nil {
+		t.Error("expected an error for empty input")
+	}
+}
+
+func TestPNG(t *testing.T) {
+	png, err := PNG("hello", 128)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.HasPrefix(png, []byte("\x89PNG\r\n\x1a\n")) {
+		t.Error("output is not a valid PNG")
+	}
+}
+
+func TestPNGEmpty(t *testing.T) {
+	if _, err := PNG("", 128); err == nil {
+		t.Error("expected an error for empty input")
+	}
+}


### PR DESCRIPTION
Adds a `qr` command that turns any value into a QR code.

- `swiss qr -v "https://..."` prints a **scannable QR in the terminal** (compact half-block rendering).
- `swiss qr -v "..." -o out.png --size 320` writes a **PNG** instead.
- Reads from stdin like the rest: `echo url | swiss qr -v -`.

Uses `github.com/skip2/go-qrcode`. Tests cover terminal + PNG output and the empty-input error. `go test`, `go vet`, `gofmt` clean; `goreleaser build --snapshot` succeeds.