### PR TITLE
Raycast: drop unused @raycast/utils dependency

### DIFF
--- a/raycast/package-lock.json
+++ b/raycast/package-lock.json
@@ -7,8 +7,7 @@
       "name": "swiss",
       "license": "MIT",
       "dependencies": {
-        "@raycast/api": "^1.103.0",
-        "@raycast/utils": "^2.2.0"
+        "@raycast/api": "^1.103.0"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^2.0.4",
@@ -1214,24 +1213,6 @@
         "eslint": ">=8.23.0"
       }
     },
-    "node_modules/@raycast/utils": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@raycast/utils/-/utils-2.2.6.tgz",
-      "integrity": "sha512-/6NUftsaNjboTOhTiadRhQ+hgfsg9AxKdYCpGGbwfUghTX9M+ljbGBesCxQ+X5GBIBM+9lH3ma7GMwZPSPzJgw==",
-      "license": "MIT",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      },
-      "peerDependencies": {
-        "@raycast/api": ">=1.99.4",
-        "react": ">=19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1782,15 +1763,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",

--- a/raycast/package.json
+++ b/raycast/package.json
@@ -65,8 +65,7 @@
     }
   ],
   "dependencies": {
-    "@raycast/api": "^1.103.0",
-    "@raycast/utils": "^2.2.0"
+    "@raycast/api": "^1.103.0"
   },
   "devDependencies": {
     "@raycast/eslint-config": "^2.0.4",


### PR DESCRIPTION
The extension only uses @raycast/api at runtime; @raycast/utils was listed but never imported.