### PR TITLE
Fix Raycast QR command typecheck (Icon.QrCode -> Icon.BarCode)

### DIFF
--- a/raycast/src/qrcode.tsx
+++ b/raycast/src/qrcode.tsx
@@ -90,7 +90,7 @@ export default function Command() {
     >
       {!input.trim() ? (
         <List.EmptyView
-          icon={Icon.QrCode}
+          icon={Icon.BarCode}
           title="Generate a QR Code"
           description="Type or paste a value or URL. Generated locally with the swiss CLI."
         />
@@ -98,7 +98,7 @@ export default function Command() {
         <List.Item
           title="QR Code"
           subtitle={png ? "Scannable PNG" : error ? "Error" : "Generating…"}
-          icon={Icon.QrCode}
+          icon={Icon.BarCode}
           detail={<List.Item.Detail markdown={markdown} />}
           actions={
             <ActionPanel>


### PR DESCRIPTION
`Icon.QrCode` isn't in @raycast/api 1.104.x (the version the store CI uses), so the publish PR's `tsc` check failed. Switched to `Icon.BarCode`. Verified with a clean `npm ci` + `tsc --noEmit` + `ray build`/`ray lint`.